### PR TITLE
Add live preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lodash": "^4.17.4",
     "node-sass-chokidar": "^0.0.3",
     "npm-run-all": "^4.1.2",
+    "query-string": "^5.0.1",
     "react": "^16.1.1",
     "react-dom": "^16.1.1",
     "react-router-dom": "^4.2.2",

--- a/src/pages/Service.js
+++ b/src/pages/Service.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { get } from 'lodash';
 import axios from 'axios';
+import { parse } from 'query-string';
 
 import ContentItems from 'components/ContentItems';
 import RelatedLinks from 'components/RelatedLinks';
@@ -20,6 +21,16 @@ class Service extends Component {
 
 
   componentDidMount() {
+    if (process.env.NODE_ENV !== 'production') {
+      // Allow querystrings to set data, which is used in joplin for livepreview
+      const query = parse(this.props.location.search);
+      if (query.preview) {
+        const data = JSON.parse(query.d);
+        this.setState({ data: data });
+        return;
+      }
+    }
+
     axios
       .get(`${process.env.REACT_APP_CMS_ENDPOINT}/pages/${this.props.match.params.id}?fields=content,extra_content,theme(text)`)
       .then(res => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1894,6 +1894,10 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+
 deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
@@ -5544,6 +5548,14 @@ query-string@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
   dependencies:
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
+
+query-string@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.0.1.tgz#6e2b86fe0e08aef682ecbe86e85834765402bd88"
+  dependencies:
+    decode-uri-component "^0.2.0"
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 


### PR DESCRIPTION
This gets compiled out in production (since @ifsimicoded rightly pointed out this could be an easy target for attackers), but will allow joplin to pass over URL params to set the correct data.

I've been testing this locally and I don't seem to run into any length limitations. If that happens we'll need to compress the data, but I don't want to do that before it's necessary.