### PR TITLE
Deploy to heroku

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,0 @@
-*
-!public/
-!src/
-!package.json
-!yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
-from node
+FROM node
+
 RUN mkdir /app
 WORKDIR /app
-ENV PORT=80
+
+ENV PORT ${PORT:-80}
 ENV NODE_PATH=src
+
 COPY yarn.lock /app/yarn.lock
 COPY package.json /app/package.json
 RUN yarn
+
 COPY public /app/public
 COPY src /app/src
-EXPOSE 80
+
+EXPOSE $PORT
 CMD [ "yarn", "start" ]

--- a/README.md
+++ b/README.md
@@ -18,20 +18,11 @@ This will update your container's yarn.lock and package.json files.
 Your local host machine's yarn.lock and package.json files will also be updated via mounted docker volumes. These local files are versioned and should be checked into git.
 
 
-To access container via terminal
+Add a package via yarn (https://yarnpkg.com/lang/en/docs/cli/add/)
 ```
-docker exec -it janis /bin/bash
-```
-
-Add a package via yarn add as you normally would (https://yarnpkg.com/lang/en/docs/cli/add/)
-```
-yarn add <package name>
+docker exec --interactive --tty janis yarn add <package name>
 ```
 
-Exit container
-```
-exit
-```
 ---
 
 ## Accessibility Guidelines (WIP)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+APP='janis-staging'
+
+CURRENT_CONFIG=$(heroku config --app "$APP")
+
+if [[ $CURRENT_CONFIG != *"REACT_APP_CMS_ENDPOINT"* ]]; then
+    heroku config:set REACT_APP_CMS_ENDPOINT=https://joplin-staging.herokuapp.com/api --app "$APP"
+fi
+
+heroku container:push web --app "$APP"

--- a/scripts/serve-local.sh
+++ b/scripts/serve-local.sh
@@ -16,5 +16,5 @@ docker run \
     --volume "$PWD/public:/app/public" \
     --volume "$PWD/package.json:/app/package.json" \
     --volume "$PWD/yarn.lock:/app/yarn.lock" \
-    -e "REACT_APP_CMS_ENDPOINT=http://localhost:8000/api" \
+    --env "REACT_APP_CMS_ENDPOINT=http://localhost:8000/api" \
     "$TAG" "$@"


### PR DESCRIPTION
Add a script for deploying to heroku

Some other tweaks
- Don't ignore any files for docker because explicitly allowing certain folders seems to confuse some tools
- Modify Dockerfile to accept `PORT` environment variable, which gets set by heroku
- Change instructions for adding packages so it's 1 command instead of several
- Use the longer form for flags in bash so it's easier to read