### PR TITLE
Update graphql usage

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,7 @@ class App extends Component {
             <Route exact path="/" component={HomePage} />
             <Route exact path="/services" component={ServicesIndex} />
             <Route exact path="/search" component={SearchPage} />
-            <Route path="/service/:id" component={Service} />
+            <Route path="/service/:slug" component={Service} />
           </section>
           <Footer />
         </div>

--- a/src/components/layout/RelatedLinks.js
+++ b/src/components/layout/RelatedLinks.js
@@ -20,7 +20,7 @@ class RelatedLinks extends Component {
               <div key={service.id} className="col-xs-12 col-md-6 col-lg-4">
               <ListLink
                 id={service.id}
-                url={`/service/${service.id}`}
+                url={`/service/${service.slug}`}
                 text={service.title}
                 isBoxType="true"
               />

--- a/src/pages/Service.js
+++ b/src/pages/Service.js
@@ -74,7 +74,7 @@ class Service extends Component {
     const steps = get(data, "content", null);
     const contentItems = get(data, "extraContent", null);
     const contacts = get(data, "contacts.edges", []).map((n) => this.cleanContact(n.node.contact));
-    const relatedlinks = get(jsonFileData, "servicesRelated", null);
+    const relatedlinks = get(data, "related", null);
     const services311 = get(jsonFileData, "services311", null);
 
     return (

--- a/src/pages/Service.js
+++ b/src/pages/Service.js
@@ -9,6 +9,7 @@ import RelatedLinks from 'components/layout/RelatedLinks';
 import FormFeedback from 'components/layout/FormFeedback';
 import Service311 from 'components/layout/Service311';
 import WYSIWYG from 'components/modules/WYSIWYG';
+import servicePageQuery from 'queries/servicePageQuery';
 
 import jsonFileData from '__tmpdata/services';
 
@@ -45,54 +46,15 @@ class Service extends Component {
       }
     }
 
-    const queryBody = `{
-      preview(pk: ${this.props.match.params.id}, showPreview: false) {
-        id
-        title
-        slug
-        topic {
-          id
-          text
-        }
-        content
-        extraContent
-        contacts {
-          edges {
-            node {
-              contact {
-                name
-                email
-                phone
-                hours {
-                  edges {
-                    node {
-                      dayOfWeek
-                      startTime
-                      endTime
-                    }
-                  }
-                }
-                location {
-                  name
-                  street
-                  city
-                  state
-                  zip
-                  country
-                }
-              }
-            }
-          }
-        }
-      }
-    }`;
-
     axios
       .post(`${process.env.REACT_APP_CMS_ENDPOINT}/graphql/`, {
-        query: queryBody,
+        query: servicePageQuery,
+        variables: {
+          slug: this.props.match.params.slug,
+        }
       })
       .then(res => {
-        this.setState({ data: res.data.data.preview });
+        this.setState({ data: res.data.data.servicePage });
       })
       .catch(err => console.log(err))
   }

--- a/src/pages/Services.js
+++ b/src/pages/Services.js
@@ -7,6 +7,7 @@ import jsonFileData from '__tmpdata/services';
 import FormFeedback from 'components/layout/FormFeedback';
 import Service311 from 'components/layout/Service311';
 import ListLink from 'components/modules/ListLink';
+import allServicePagesQuery from 'queries/allServicePagesQuery';
 
 class ServicesIndex extends Component {
 
@@ -19,9 +20,11 @@ class ServicesIndex extends Component {
 
   componentDidMount() {
     axios
-      .get(`${process.env.REACT_APP_CMS_ENDPOINT}/pages/?type=base.ServicePage`)
+      .post(`${process.env.REACT_APP_CMS_ENDPOINT}/graphql/`, {
+        query: allServicePagesQuery,
+      })
       .then(res => {
-        this.setState({ data: res.data })
+        this.setState({ data: res.data.data.allServicePages })
       })
       .catch(err => console.log(err))
   }
@@ -31,7 +34,7 @@ class ServicesIndex extends Component {
     const title = get(jsonFileData, "servicepage.title", "");
     const body = get(jsonFileData, "servicepage.body", "");
     const services311 = get(jsonFileData, "services311", []);
-    const { items: services = [] } = this.state.data
+    const { edges: services = [] } = this.state.data
 
     return (
       <div>
@@ -50,12 +53,12 @@ class ServicesIndex extends Component {
           <div className="wrapper">
             <div className="row">
             {
-              services.map((service) =>
+              services.map(({ node: service }) =>
                 <div className="col-xs-12 col-md-6 col-lg-4">
                   <ListLink
                     key={service.id}
                     id={service.id}
-                    url={`/service/${service.id}`}
+                    url={`/service/${service.slug}`}
                     text={service.title}
                     isBoxType={true}
                   />

--- a/src/queries/allServicePagesQuery.js
+++ b/src/queries/allServicePagesQuery.js
@@ -1,0 +1,14 @@
+const allServicePagesQuery = `
+  query allServicePages {
+    allServicePages {
+      edges {
+        node {
+          id
+          title
+          slug
+        }
+      }
+    }
+  }`;
+
+export default allServicePagesQuery;

--- a/src/queries/servicePageQuery.js
+++ b/src/queries/servicePageQuery.js
@@ -1,0 +1,44 @@
+const servicePageQuery = `
+  query servicePage($pk:Int, $slug:String) {
+    servicePage(pk: $pk, slug: $slug) {
+      id
+      title
+      slug
+      topic {
+        id
+        text
+      }
+      content
+      extraContent
+      contacts {
+        edges {
+          node {
+            contact {
+              name
+              email
+              phone
+              hours {
+                edges {
+                  node {
+                    dayOfWeek
+                    startTime
+                    endTime
+                  }
+                }
+              }
+              location {
+                name
+                street
+                city
+                state
+                zip
+                country
+              }
+            }
+          }
+        }
+      }
+    }
+  }`;
+
+export default servicePageQuery;

--- a/src/queries/servicePageQuery.js
+++ b/src/queries/servicePageQuery.js
@@ -10,6 +10,11 @@ const servicePageQuery = `
       }
       content
       extraContent
+      related {
+        id
+        slug
+        title
+      }
       contacts {
         edges {
           node {


### PR DESCRIPTION
- switch to navigating via slugs instead of IDs
- change `/services` to use graphql
- moved queries into own files to make the JS easier to read
- updated single page query to pass in variables
- API naming is changing slightly to make it more like other graphql APIs

Look! It works!
![wonks](http://g.recordit.co/vq2GybeShv.gif)