### PR TITLE
Use react router Link component

### DIFF
--- a/src/js/components/LanguageWrapper.js
+++ b/src/js/components/LanguageWrapper.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { BrowserRouter as Router, Route } from 'react-router-dom'
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
 import { IntlProvider } from 'react-intl'
 import locale from 'browser-locale'
 import Cookies from 'js-cookie'
@@ -15,6 +15,7 @@ import Home from "js/pages/Home"
 import Search from "js/pages/Search"
 import Services from "js/pages/Services"
 import Service from "js/pages/Service"
+import Topic from "js/pages/Topic"
 
 import { SUPPORTED_LANGUAGES } from 'js/constants/languages'
 
@@ -73,10 +74,13 @@ class LanguageWrapper extends Component {
               </section>
             )} />
             <section className="coa-main">
-              <Route exact path={`/`} component={Home} {...this.props} />
-              <Route exact path={`/:lang?/services`} component={Services} {...this.props} />
-              <Route exact path={`/:lang?/search`} component={Search} {...this.props} />
-              <Route path={`/:lang?/service/:slug`} render={(props) => <Service {...props} lang={this.state.lang}/>} />
+              <Switch>
+                <Route exact path={`/`} component={Home} {...this.props} />
+                <Route exact path={`/:lang?/services`} component={Services} {...this.props} />
+                <Route exact path={`/:lang?/topic/:id`} component={Topic} {...this.props} />
+                <Route exact path={`/:lang?/search`} component={Search} {...this.props} />
+                <Route path={`/:lang?/service/:slug`} render={(props) => <Service {...props} lang={this.state.lang}/>} />
+              </Switch>
             </section>
             <Footer />
           </div>

--- a/src/js/modules/ListLink.js
+++ b/src/js/modules/ListLink.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
 
 class ListLink extends Component {
 
@@ -7,14 +8,14 @@ class ListLink extends Component {
     const { id, url, text, isBoxType } = this.props;
 
     return (
-      <a
+      <Link
         className={ `coa-ListLink ${(isBoxType && "coa-ListLink--boxprimary" )}` }
         key={id}
-        href={url}
+        to={url}
       >
         <span>{text}</span>
         <i className="fa fa-chevron-right" aria-hidden="true"></i>
-      </a>
+      </Link>
     );
   }
 }

--- a/src/js/page_sections/Header.js
+++ b/src/js/page_sections/Header.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import SearchSVG from 'js/svg/Search';
 import Navmenu from 'js/page_sections/Navmenu';
+import { Link } from 'react-router-dom';
 
 class Header extends Component {
   constructor(props) {
@@ -28,10 +29,10 @@ class Header extends Component {
                 MENU
               </span>
               <span className="coa-text-spacer--vertical"></span>
-              <a href="/">AUSTIN.GOV</a>
+              <Link to="/">AUSTIN.GOV</Link>
             </div>
             <div className="col-xs-6 coa-Header__search">
-              <a href="/search">Search <SearchSVG size="18"/></a>
+              <Link to="/search"> Search <SearchSVG size="18"/></Link>
             </div>
           </div>
         </div>

--- a/src/js/page_sections/Navmenu.js
+++ b/src/js/page_sections/Navmenu.js
@@ -98,7 +98,7 @@ class Navmenu extends Component {
 
             return (
               <li key={parentLink.id}>
-                <Link to="/services" className={this.getParentMenuItemClassName(parentLink)}>
+                <Link to={`/topic/${parentLink.id}`} className={this.getParentMenuItemClassName(parentLink)}>
                   { parentLink.text }
                 </Link>
 

--- a/src/js/page_sections/RelatedLinks.js
+++ b/src/js/page_sections/RelatedLinks.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import SectionTitle from 'js/modules/SectionTitle';
 import ListLink from 'js/modules/ListLink';
+import { Link } from 'react-router-dom';
 
 class RelatedLinks extends Component {
 
@@ -29,7 +30,9 @@ class RelatedLinks extends Component {
           }
           </div>
 
-          <a className="coa-section__link" href={`/topic/${topicId}`}>See all services under {topicName}</a>
+          <Link className="coa-section__link" to={`/topic/${topicId}`}>
+            See all services under {topicName}
+          </Link>
         </div>
       </div>
     );

--- a/src/js/pages/Service.js
+++ b/src/js/pages/Service.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { get } from 'lodash';
 import axios from 'axios';
 import { parse } from 'query-string';
+import { Link } from 'react-router-dom';
 
 import ContentItems from 'js/page_sections/ContentItems';
 import Contact from 'js/page_sections/Contact';
@@ -103,7 +104,11 @@ class Service extends Component {
             <div className="coa-main__left col-xs-12 col-lg-8">
 
               <div className="coa-section">
-                { topicId && ( <a className="coa-main__breadcrumb" href={`/topic/${topicId}`}>{topicName}</a> )}
+                { topicId && (
+                  <Link className="coa-main__breadcrumb" to={`/topic/${topicId}`}>
+                    {topicName}
+                  </Link>
+                )}
                 <h2 className="coa-main__title">{title}</h2>
                 { steps && ( <div className="coa-main__steps"><HtmlFromAdmin content={steps} /></div> )}
               </div>


### PR DESCRIPTION
This PR is doing basic stuff. Replacing were we used `<a>` tags with the `<Link>` component provided by react-router-dom so we have that quick and smooth single page app style page transition instead of a page reload. 

When we switch to something SSR, that framework will likely have their own Link component provided with the routing library so we'll need to update which library we import Link from along with any other refactors required.

I also wrapped our Page Component routes in a `<Switch>` since they should all be mutually exclusive. We never render the Home Page and a Service Page together.