### PR TITLE
Usee a default language if none is defined

### DIFF
--- a/src/js/page_sections/I18nBanner.js
+++ b/src/js/page_sections/I18nBanner.js
@@ -60,9 +60,10 @@ class I18nBanner extends Component {
   }
 
   getActiveLanguageTitle = () => {
-    const activeLanguage = SUPPORTED_LANGUAGES.find((lang) => {
+    let activeLanguage = SUPPORTED_LANGUAGES.find((lang) => {
       return lang.code === this.props.activeLanguage;
     });
+    activeLanguage = activeLanguage || SUPPORTED_LANGUAGES[0];
     return activeLanguage.title;
   }
 


### PR DESCRIPTION
When going to localhost:3000 for the first time, I was getting this error

![error](https://user-images.githubusercontent.com/272675/34898396-84aa49d4-f7b8-11e7-9bdb-7491dd1f26b4.png)

If there's no language set, we'll just assume the first member of `SUPPORTED_LANGUAGES` should be used.