### PR TITLE
Fix #79: Collapse contact hours and make expandable 

### DIFF
--- a/src/css/base/_variables_coa.scss
+++ b/src/css/base/_variables_coa.scss
@@ -18,6 +18,8 @@ $coa-fullwidth-margin: 2rem;
 $coa-container-maxwidth: 1200px;
 $coa-textwrap-width: 545px;
 
+$coa-font-semibold: 600;
+
 @mixin box-verticalcenter($height: auto) {
   align-items: center;
   display: flex;

--- a/src/css/coa.scss
+++ b/src/css/coa.scss
@@ -20,6 +20,7 @@
 @import 'css/modules/section';
 @import 'css/modules/ListLink';
 @import 'css/modules/HtmlFromAdmin';
+@import 'css/modules/Hours';
 
 // layout
 @import 'css/page_sections/main';

--- a/src/css/helpers/_helpers.scss
+++ b/src/css/helpers/_helpers.scss
@@ -3,8 +3,8 @@
 }
 
 .hidden--sm {
-// --> display none for small width screens and higher
-  display: none;
+// --> display none for small width screens and higher | !important must be included due to display conflicts lower in css chain
+  display: none !important;
   @include media($medium-screen) {
     display: inline;
   }

--- a/src/css/modules/_Hours.scss
+++ b/src/css/modules/_Hours.scss
@@ -1,0 +1,7 @@
+.coa-Hours__today {
+  // font-weight: $coa-font-semibold;
+}
+
+.coa-Hours__today-bolded {
+  font-weight: $coa-font-semibold;
+}

--- a/src/js/modules/Hours.js
+++ b/src/js/modules/Hours.js
@@ -4,6 +4,7 @@ import moment from 'moment';
 
 class Hours extends Component {
   // TODO:
+  //  - Format in 12-hour time (make 12/24 a user option?)
 
 
   constructor(props) {
@@ -168,11 +169,14 @@ class Hours extends Component {
   displayAllDays(hours) {
     // strips all hidden tags from all days
     let newHours = hours;
-    for (let i = 0; i < newHours.length; i++) {
-      newHours[i].classes = newHours[i].classes.replace('hidden--sm', '');
-      newHours[i].classes = newHours[i].classes.replace('hidden--md', '');
-    }
-    return newHours;
+    hours.map((hour) => {
+      if (hour.dayOfWeek.toLowerCase() == this.state.today.format('dddd').toLowerCase()){
+        hour.classes = "coa-Hours__today-bolded";
+      }
+      hour.classes = hour.classes.replace('hidden--sm', '');
+      hour.classes = hour.classes.replace('hidden--md', '');
+    })
+    return hours;
   }
 
   render() {

--- a/src/js/modules/Hours.js
+++ b/src/js/modules/Hours.js
@@ -18,10 +18,73 @@ class Hours extends Component {
     console.log(this.state.days);
   }
 
+  createDay(dayOfWeek, startTime, endTime) {
+    return {
+      'dayOfWeek': dayOfWeek,
+      'startTime': startTime,
+      'endTime': endTime
+    }
+  }
+
   sortDays(days) {
-    // TODO: method that returns given list of days sorted (ie. M, T, W, TH, F from F, W, TH, M, T)
-    // MAYBE: adds missing days
-    return days
+    // returns a complete sorted list of days in the week, with non-given days created as CLOSED
+    let newDays = new Array(7);
+    for (let i = 0; i < days.length; i++) {
+      switch (days[i].dayOfWeek) {
+        case 'SUNDAY':
+          newDays[0] = days[i];
+          break;
+        case 'MONDAY':
+          newDays[1] = days[i];
+          break;
+        case 'TUESDAY':
+          newDays[2] = days[i];
+          break;
+        case 'WEDNESDAY':
+          newDays[3] = days[i];
+          break;
+        case 'THURSDAY':
+          newDays[4] = days[i];
+          break;
+        case 'FRIDAY':
+          newDays[5] = days[i];
+          break;
+        case 'SATURDAY':
+          newDays[6] = days[i];
+          break;
+        default:
+          break;
+      }
+    }
+    for (let i = 0; i < newDays.length; i++) {
+      const CLOSED = 'CLOSED';
+      if (!newDays[i]) {
+        switch (i) {
+          case 0:
+            newDays[0] = this.createDay('SUNDAY', CLOSED, CLOSED);
+            break;
+          case 1:
+            newDays[1] = this.createDay('MONDAY', CLOSED, CLOSED);
+            break;
+          case 2:
+            newDays[2] = this.createDay('TUESDAY', CLOSED, CLOSED);
+            break;
+          case 3:
+            newDays[3] = this.createDay('WEDNESDAY', CLOSED, CLOSED);
+            break;
+          case 4:
+            newDays[4] = this.createDay('THURSDAY', CLOSED, CLOSED);
+            break;
+          case 5:
+            newDays[5] = this.createDay('FRIDAY', CLOSED, CLOSED);
+            break;
+          case 6:
+            newDays[6] = this.createDay('SATURDAY', CLOSED, CLOSED);
+            break;
+        }
+      }
+    }
+    return newDays
   }
 
   markTodayClasses(day, compare) {
@@ -67,10 +130,20 @@ class Hours extends Component {
 
 class IndividualDay extends Component {
     render() {
+      let startTime = this.props.day.startTime;
+      let endTime = this.props.day.endTime;
+
+      if (!typeof startTime === 'string') {
+        startTime = moment(this.props.day.startTime, "HH:mm:ss").format('h:mm A');
+      }
+
+      if (!typeof endTime === 'string') {
+        endTime = moment(this.props.day.endTime, "HH:mm:ss").format('h:mm A');
+      }
       return (
         <tr key={this.props.key} className={this.props.day.classes}>
           <th scope="row">{this.props.day.dayOfWeek}</th>
-          <td>{moment(this.props.day.startTime, "HH:mm:ss").format('h:mm A')} - {moment(this.props.day.endTime, "HH:mm:ss").format('h:mm A')}</td>
+          <td>{startTime} - {endTime}</td>
         </tr>
       )
     }

--- a/src/js/modules/Hours.js
+++ b/src/js/modules/Hours.js
@@ -4,9 +4,7 @@ import moment from 'moment';
 
 class Hours extends Component {
   // TODO:
-  //  - create all seven days (do in WagTail?)
-  //  - create display all method
-  //  - create hide all but today method (same method as above?)
+  //  - Hours don't change from page to page... Should update when given new contact information.
 
   constructor(props) {
     super(props);
@@ -153,9 +151,9 @@ class Hours extends Component {
           </thead>
           <tbody>
             { hours.map((day, index) => <IndividualDay day={day} key={index} />)}
-            <tr><button onClick={() => this.handleClick(hours)}>{showHide}</button></tr>
           </tbody>
         </table>
+        <button onClick={() => this.handleClick(hours)}>{showHide}</button>
       </div>
     );
 

--- a/src/js/modules/Hours.js
+++ b/src/js/modules/Hours.js
@@ -6,7 +6,6 @@ class Hours extends Component {
   // TODO:
   //  - Format in 12-hour time (make 12/24 a user option?)
 
-
   constructor(props) {
     super(props);
     let today = moment()
@@ -227,17 +226,3 @@ class IndividualDay extends Component {
 
 
 export default Hours;
-
-
-//===========
-// ORIGINAL hours mapping
-// {
-//
-//   hours.map((hour, index) =>
-//     // className = check to see if date is today, insert returned classes
-//     <tr key={index} className={this.markTodayClasses(hour, this.state.today)}>
-//       <th scope="row">{hour.dayOfWeek}</th>
-//       <td>{moment(hour.startTime, "HH:mm:ss").format('h:mm A')} - {moment(hour.endTime, "HH:mm:ss").format('h:mm A')}</td>
-//     </tr>
-//   )
-// }

--- a/src/js/modules/Hours.js
+++ b/src/js/modules/Hours.js
@@ -3,9 +3,22 @@ import moment from 'moment';
 
 class Hours extends Component {
 
+  isToday(day) {
+    // Returns hidden classes for rows that aren't today | returns empty string for today
+    console.log('\n\n\n\n');
+    console.log(day.dayOfWeek.toLowerCase());
+    let today = moment();
+    if (day.dayOfWeek.toLowerCase() == today.format('dddd').toLowerCase())
+      return "";
+    else
+      return "hidden--sm hidden--md hidden";
+  }
+
   render() {
 
     const { hours } = this.props;
+    let today = moment();
+
 
     return (hours) && (
 
@@ -21,7 +34,8 @@ class Hours extends Component {
           <tbody>
           {
             hours.map((hour, index) =>
-              <tr key={index}>
+              // className = check to see if date is today
+              <tr key={index} className={this.isToday(hour)}>
                 <th scope="row">{hour.dayOfWeek}</th>
                 <td>{moment(hour.startTime, "HH:mm:ss").format('h:mm A')} - {moment(hour.endTime, "HH:mm:ss").format('h:mm A')}</td>
               </tr>

--- a/src/js/modules/Hours.js
+++ b/src/js/modules/Hours.js
@@ -1,27 +1,51 @@
 import React, {Component} from 'react';
 import moment from 'moment';
 
-class Hours extends Component {
 
-  isToday(day) {
+class Hours extends Component {
+  // TODO:
+  //  - create all seven days (do in WagTail?)
+  //  - create display all method
+  //  - create hide all but today method (same method as above?)
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      days: this.sortDays(this.props.hours),
+      today: moment(),
+    }
+    console.log('\n\n\n');
+    console.log(this.state.days);
+  }
+
+  sortDays(days) {
+    // TODO: method that returns given list of days sorted (ie. M, T, W, TH, F from F, W, TH, M, T)
+    // MAYBE: adds missing days
+    return days
+  }
+
+  markTodayClasses(day, compare) {
     // Returns hidden classes for rows that aren't today | returns empty string for today
-    console.log('\n\n\n\n');
-    console.log(day.dayOfWeek.toLowerCase());
     let today = moment();
     if (day.dayOfWeek.toLowerCase() == today.format('dddd').toLowerCase())
-      return "";
+      return "coa-Hours__today";
     else
-      return "hidden--sm hidden--md hidden";
+      return "hidden--sm hidden--md";
+  }
+
+  markToday(days, today) {
+    // iterates through given days, classes prop to those from markTodayClasses
+    for (let i = 0; i < days.length; i++) {
+      days[i].classes = this.markTodayClasses(days[i], today);
+    }
+    return days;
   }
 
   render() {
-
-    const { hours } = this.props;
-    let today = moment();
-
+    // const { hours } = this.props;
+    const hours = this.markToday(this.state.days.slice(), this.state.today);
 
     return (hours) && (
-
       <div className="coa-section__map">
         <h5>Hours</h5>
         <table className="usa-table-borderless">
@@ -32,15 +56,7 @@ class Hours extends Component {
             </tr>
           </thead>
           <tbody>
-          {
-            hours.map((hour, index) =>
-              // className = check to see if date is today
-              <tr key={index} className={this.isToday(hour)}>
-                <th scope="row">{hour.dayOfWeek}</th>
-                <td>{moment(hour.startTime, "HH:mm:ss").format('h:mm A')} - {moment(hour.endTime, "HH:mm:ss").format('h:mm A')}</td>
-              </tr>
-            )
-          }
+            { hours.map((day, index) => <IndividualDay day={day} key={index} />)}
           </tbody>
         </table>
       </div>
@@ -49,4 +65,30 @@ class Hours extends Component {
   }
 }
 
+class IndividualDay extends Component {
+    render() {
+      return (
+        <tr key={this.props.key} className={this.props.day.classes}>
+          <th scope="row">{this.props.day.dayOfWeek}</th>
+          <td>{moment(this.props.day.startTime, "HH:mm:ss").format('h:mm A')} - {moment(this.props.day.endTime, "HH:mm:ss").format('h:mm A')}</td>
+        </tr>
+      )
+    }
+}
+
+
 export default Hours;
+
+
+//===========
+// ORIGINAL hours mapping
+// {
+//
+//   hours.map((hour, index) =>
+//     // className = check to see if date is today, insert returned classes
+//     <tr key={index} className={this.markTodayClasses(hour, this.state.today)}>
+//       <th scope="row">{hour.dayOfWeek}</th>
+//       <td>{moment(hour.startTime, "HH:mm:ss").format('h:mm A')} - {moment(hour.endTime, "HH:mm:ss").format('h:mm A')}</td>
+//     </tr>
+//   )
+// }

--- a/src/js/modules/Hours.js
+++ b/src/js/modules/Hours.js
@@ -9,15 +9,24 @@ class Hours extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      days: this.markToday(this.sortDays(this.props.hours), moment()),
+      hours: this.markToday(this.sortDays(this.props.hours), moment()),
       today: moment(),
-      showHide: 'Show All',
+      showHide: 'Show All Hours',
     }
-    console.log('\n\n\n');
-    console.log(this.state.days);
+  }
+
+  componentWillReceiveProps(newProps) {
+    // State must be updated each time component renders in order to update to
+    //    correct hours while maintaining hide/display method capability
+    this.setState({
+      hours: this.markToday(this.sortDays(newProps.hours), moment()),
+      today: moment(),
+      showHide: 'Show All Hours',
+    });
   }
 
   createDay(dayOfWeek, startTime, endTime) {
+    // Used for 'empty' days | empty dates from Wagtail
     return {
       'dayOfWeek': dayOfWeek,
       'startTime': startTime,
@@ -28,6 +37,8 @@ class Hours extends Component {
   sortDays(days) {
     // returns a complete sorted list of days in the week, with non-given days created as CLOSED
     let newDays = new Array(7);
+
+    // this loop simply sorts the days
     for (let i = 0; i < days.length; i++) {
       switch (days[i].dayOfWeek) {
         case 'SUNDAY':
@@ -55,6 +66,9 @@ class Hours extends Component {
           break;
       }
     }
+
+    // Creates a complete list of days. If a day isn't included in given 'days'
+    //  list, this loop will call a method to create a 'closed' day
     for (let i = 0; i < newDays.length; i++) {
       const CLOSED = 'CLOSED';
       if (!newDays[i]) {
@@ -83,6 +97,7 @@ class Hours extends Component {
         }
       }
     }
+
     return newDays
   }
 
@@ -104,18 +119,19 @@ class Hours extends Component {
   }
 
   handleClick(hours) {
+    // handles click for show/display button
     let newHours;
     let showHide;
-    if (this.state.showHide === 'Show All') {
+    if (this.state.showHide === 'Show All Hours') {
       newHours = this.displayAllDays(hours);
-      showHide = 'Hide Others';
+      showHide = 'Show Only Today';
     } else {
       newHours = this.markToday(hours, moment());
-      showHide = 'Show All';
+      showHide = 'Show All Hours';
     }
 
     this.setState({
-      days: newHours,
+      hours: newHours,
       today: this.state.today,
       showHide: showHide,
     });
@@ -131,14 +147,10 @@ class Hours extends Component {
     return newHours;
   }
 
-  hideOtherDays(hours) {
-    let newDays = hours;
-  }
-
   render() {
-    // const { hours } = this.props;
-    const hours = this.state.days.slice();
-    let showHide = this.state.showHide + ' Hours';
+    const hours = this.state.hours.slice();
+    let showHide = this.state.showHide;
+
     return (hours) && (
       <div className="coa-section__map">
         <h5>Hours</h5>

--- a/src/js/modules/Hours.js
+++ b/src/js/modules/Hours.js
@@ -11,8 +11,9 @@ class Hours extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      days: this.sortDays(this.props.hours),
+      days: this.markToday(this.sortDays(this.props.hours), moment()),
       today: moment(),
+      showHide: 'Show All',
     }
     console.log('\n\n\n');
     console.log(this.state.days);
@@ -88,9 +89,9 @@ class Hours extends Component {
   }
 
   markTodayClasses(day, compare) {
-    // Returns hidden classes for rows that aren't today | returns empty string for today
-    let today = moment();
-    if (day.dayOfWeek.toLowerCase() == today.format('dddd').toLowerCase())
+    // day and compare are moment() objects; displayAll is Boolean
+    // Returns hidden classes for rows that aren't today if displayAll == false | returns empty string for today
+    if (day.dayOfWeek.toLowerCase() == compare.format('dddd').toLowerCase())
       return "coa-Hours__today";
     else
       return "hidden--sm hidden--md";
@@ -104,10 +105,42 @@ class Hours extends Component {
     return days;
   }
 
+  handleClick(hours) {
+    let newHours;
+    let showHide;
+    if (this.state.showHide === 'Show All') {
+      newHours = this.displayAllDays(hours);
+      showHide = 'Hide Others';
+    } else {
+      newHours = this.markToday(hours, moment());
+      showHide = 'Show All';
+    }
+
+    this.setState({
+      days: newHours,
+      today: this.state.today,
+      showHide: showHide,
+    });
+  }
+
+  displayAllDays(hours) {
+    // strips all hidden tags from all days
+    let newHours = hours;
+    for (let i = 0; i < newHours.length; i++) {
+      newHours[i].classes = newHours[i].classes.replace('hidden--sm', '');
+      newHours[i].classes = newHours[i].classes.replace('hidden--md', '');
+    }
+    return newHours;
+  }
+
+  hideOtherDays(hours) {
+    let newDays = hours;
+  }
+
   render() {
     // const { hours } = this.props;
-    const hours = this.markToday(this.state.days.slice(), this.state.today);
-
+    const hours = this.state.days.slice();
+    let showHide = this.state.showHide + ' Hours';
     return (hours) && (
       <div className="coa-section__map">
         <h5>Hours</h5>
@@ -120,6 +153,7 @@ class Hours extends Component {
           </thead>
           <tbody>
             { hours.map((day, index) => <IndividualDay day={day} key={index} />)}
+            <tr><button onClick={() => this.handleClick(hours)}>{showHide}</button></tr>
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
Fix #79 : 
- [X] defaults to current day of the week plus corresponding hours
- [X] when expanded, shows days following meaning if it's Wednesday, the expanded list starts with Wednesday, ends with Tuesday
- [ ] once expanded, current day of week and hours is bolded to Open Sans semi-bold, weight 600

Hours now display with the hours for the current day displaying first and all others hidden. I used a standard button to expand/hide other hours instead of a link or smaller button next to the current day's hours because I felt it might be a little more clear than as demonstrated in the provided screenshot/mockup. I did add the styling to make current day bolded, but Open Sans isn't included in the top-level scss file so I didn't want to touch that in fear of breaking anything else. 

Another issue is the 12-hour vs. 24-hour time format. I'm thinking it may be best to take care of this in Joplin? If not it should be a quick fix here. 
