### PR TITLE
Sort and format hours/days beginning with current day.

### DIFF
--- a/src/js/helpers/cleanData.js
+++ b/src/js/helpers/cleanData.js
@@ -1,4 +1,5 @@
 import { getPathWithLangCode } from 'js/helpers/language';
+import moment from 'moment';
 
 export const cleanContacts = (contacts) => {
 
@@ -7,7 +8,15 @@ export const cleanContacts = (contacts) => {
   return contacts.edges.map(({node: contact}) => {
     let cleaned = Object.assign(contact.contact);
     if(cleaned.hours && cleaned.hours.edges) {
-      cleaned.hours = cleaned.hours.edges.map(({ node: hours }) => hours);
+      cleaned.hours = cleaned.hours.edges.map(({ node: hours }) => {
+        hours.startTime = moment(hours.startTime, "HH:mm:ss").format('h:mm A');
+        hours.endTime = moment(hours.endTime, "HH:mm:ss").format('h:mm A');
+        let dayMoment = moment(hours.dayOfWeek, 'dddd');
+        hours.dayOfWeek = dayMoment.format('dddd');
+        hours.day = dayMoment.format('E');
+
+        return hours;
+      });
     }
     return cleaned;
   });

--- a/src/js/modules/Hours.js
+++ b/src/js/modules/Hours.js
@@ -1,11 +1,19 @@
 import React, {Component} from 'react';
 import moment from 'moment';
+import {sortBy, findIndex} from 'lodash';
 
 class Hours extends Component {
 
-  render() {
+  sort() {
+    // TODO: Joplin data MUST include data for all 7 days of week.
+    let now = moment().format('e') + "";
+    let sorted = sortBy(this.props.hours, ['day']);
+    let index = findIndex(sorted, {'day': now});
+    return sorted.splice(index).concat(sorted);
+  }
 
-    const { hours } = this.props;
+  render() {
+    const hours = this.sort();
     let JSX;
 
     if (!hours || !hours.length) {
@@ -26,7 +34,7 @@ class Hours extends Component {
               hours.map((hour, index) =>
                 <tr key={index}>
                   <th scope="row">{hour.dayOfWeek}</th>
-                  <td>{moment(hour.startTime, "HH:mm:ss").format('h:mm A')} - {moment(hour.endTime, "HH:mm:ss").format('h:mm A')}</td>
+                  <td>{ hour.startTime } - { hour.endTime }</td>
                 </tr>
               )
             }


### PR DESCRIPTION
#79 sort and displays hours. Still needs to collapse hours. Assumes Joplin provides data for all 7 days of the week.