### PR TITLE
Initial version of deploying the statically built site

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,30 @@
+FROM node AS builder
+
+RUN mkdir /app
+WORKDIR /app
+
+ENV NODE_PATH=src
+
+COPY yarn.lock /app/yarn.lock
+COPY package.json /app/package.json
+RUN yarn
+
+COPY static.config.js /app/static.config.js
+COPY .babelrc /app/.babelrc
+
+ARG CMS_API
+ENV CMS_API=${CMS_API:-https://joplin.herokuapp.com/api/graphql/}
+
+ARG CMS_MEDIA
+ENV CMS_MEDIA=${CMS_MEDIA:-https://joplin.herokuapp.com/media/}
+
+COPY src /app/src
+RUN yarn build
+
+# ============================================
+
+FROM nginx:alpine AS official
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+ENV NGINX_PORT=${PORT:-80}

--- a/app.json
+++ b/app.json
@@ -3,10 +3,10 @@
   "scripts": {
   },
   "env": {
-    "REACT_APP_CMS_ASSETS": {
+    "CMS_API": {
       "required": true
     },
-    "REACT_APP_CMS_ENDPOINT": {
+    "CMS_MEDIA": {
       "required": true
     }
   },

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,3 +1,3 @@
 build:
   docker:
-    web: Dockerfile
+    web: Dockerfile.build

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "start-js": "react-static start",
     "start": "npm-run-all -p watch-css start-js",
     "build-js": "react-static build",
-    "build": "npm-run-all build-css build-js && cp -r dist/* _dist/",
+    "build": "npm-run-all build-css build-js",
     "build-css": "node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/",
     "watch-css": "npm run build-css && node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/ --watch --recursive"
   }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,24 +1,15 @@
 #!/usr/bin/env bash
-echo "starting..."
 
 set -o errexit
 
-TAG='janis:local'
-echo "building docker image..."
-docker build --tag "$TAG" .
-echo "running docker image..."
-HOST_IP=$(ifconfig en0 | awk '$1 == "inet" {print $2}')
-docker run \
+TAG=${TAG:-janis-build:local}
+CMS_URL=${CMS_URL:-https://joplin.herokuapp.com}
+
+echo "Building image..."
+docker build \
     --rm \
-    --name janis \
-    --tty --interactive \
-    --volume "$PWD/dist:/app/_dist" \
-    --volume "$PWD/src:/app/src" \
-    --volume "$PWD/public:/app/public" \
-    --volume "$PWD/package.json:/app/package.json" \
-    --volume "$PWD/static.config.js:/app/static.config.js" \
-    --volume "$PWD/.babelrc:/app/.babelrc" \
-    --volume "$PWD/yarn.lock:/app/yarn.lock" \
-    --env "CMS_API=http://$HOST_IP:8000/api/graphql/" \
-    --env "CMS_MEDIA=http://$HOST_IP:8000/media/" \
-    "$TAG" yarn build
+    --build-arg "CMS_API=$CMS_URL/api/graphql/" \
+    --build-arg "CMS_MEDIA=$CMS_URL/media/" \
+    --tag "$TAG" \
+    --file Dockerfile.build \
+    .

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,12 +6,14 @@ APP='janis-staging'
 
 CURRENT_CONFIG=$(heroku config --app "$APP")
 
-if [[ $CURRENT_CONFIG != *"REACT_APP_CMS_ENDPOINT"* ]]; then
-    heroku config:set REACT_APP_CMS_ENDPOINT=https://joplin-staging.herokuapp.com/api --app "$APP"
+JOPLIN_URL=$(heroku apps:info --shell --app joplin  | grep web_url | cut -d= -f2)
+
+if [[ $CURRENT_CONFIG != *"CMS_API"* ]]; then
+    heroku config:set CMS_API="$JOPLIN_URL"api/graphql --app "$APP"
 fi
 
-if [[ $CURRENT_CONFIG != *"REACT_APP_CMS_ASSETS"* ]]; then
-    heroku config:set REACT_APP_CMS_ASSETS=https://joplin-staging.herokuapp.com/media --app "$APP"
+if [[ $CURRENT_CONFIG != *"CMS_MEDIA"* ]]; then
+    heroku config:set CMS_MEDIA="$JOPLIN_URL"media --app "$APP"
 fi
 
 heroku container:push web --app "$APP"

--- a/scripts/serve-build.sh
+++ b/scripts/serve-build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+TAG='janis-buildo:local'
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+. "$DIR/build.sh"
+
+echo "Waiting for requests..."
+docker run \
+  --rm \
+  --name janis-build \
+  --publish 8080:80 \
+  "$TAG" "$@"


### PR DESCRIPTION
Now we'll default to a multi-stage build:
1. Build the static files
2. Copy static files from step 1 and serve via nginx

I've created a separate `Dockerfile.build` file, though I'm not sure if that'll be the right way to separate developing (with hot reloads, etc) and deployment. This is my first attempt and we'll iterate to get the right dev experience.

Implements cityofaustin/janis#123