### PR TITLE
Return of the Language Wrapper

### DIFF
--- a/scripts/serve-local.sh
+++ b/scripts/serve-local.sh
@@ -20,5 +20,5 @@ docker run \
     --volume "$PWD/.babelrc:/app/.babelrc" \
     --volume "$PWD/yarn.lock:/app/yarn.lock" \
     --env "CMS_API=http://$HOST_IP:8000/api/graphql/" \
-    "$TAG" "$@"
     --env "CMS_MEDIA=http://$HOST_IP:8000/media" \
+    "$TAG" "$@"

--- a/src/App.js
+++ b/src/App.js
@@ -1,102 +1,30 @@
 import React, { Component } from 'react'
 import { Router, Route } from 'react-static'
-import Routes from 'react-static-routes'
-import { IntlProvider } from 'react-intl'
-import locale from 'browser-locale'
-import Cookies from 'js-cookie'
 import ReactGA from 'react-ga'
 import GoogleAnalyticsPageView from 'js/helpers/GoogleAnalyticsPageView'
-
-// page_sections
-import LanguageSelectBanner from "js/page_sections/LanguageSelectBanner"
-import Header from "js/page_sections/Header"
-import Footer from "js/page_sections/Footer"
-
-
-import { SUPPORTED_LANGUAGES } from 'js/constants/languages'
-
-
+import LanguageWrapper from "js/components/LanguageWrapper"
 
 import 'css/coa.css'
 
 ReactGA.initialize('UA-110716917-2', { debug: true });
 
-
 class App extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      lang: this.setLanguage()
-    }
-    this.daysUntilCookieExpires = 10 * 365;
-  }
-
-  parseBrowserLanguageCode = () => {
-    // Normally, we only want the two letter lowercased language abbreviation
-    // bc we aren't worried about locale (ex: en-US vs. en-UK) at this point,
-    // just language.
-    if (typeof document !== 'undefined') {
-      const twoLetterLangCode = locale().split('-')[0].toLowerCase();
-      // But we do want to support two types of Chinese (zh-tw & zh-cn)
-      const isChinese = twoLetterLangCode === 'zh';
-      return isChinese ? locale().toLowerCase() : twoLetterLangCode;
-    }
-  }
-
-  setLanguage = () => {
-    const cookieLanguage = Cookies.get('lang');
-    const browserLocale = this.parseBrowserLanguageCode();
-    let language = '';
-
-    const isLanguageCodeInPath = SUPPORTED_LANGUAGES
-      .map(lang => lang.code)
-      .includes(this.props.urlPathLanguage)
-
-    if (isLanguageCodeInPath) {
-      language = this.props.urlPathLanguage
-    } else if (cookieLanguage) {
-      language = cookieLanguage
-    } else {
-      language = browserLocale || 'en'
-    }
-
-    Cookies.set('lang', language, { expires: this.daysUntilCookieExpires })
-    return language
-  }
-
-
-  handleLanguageUpdate = (newLang) => {
-    Cookies.set('lang', newLang, { expires: this.daysUntilCookieExpires })
-    this.setState({ lang: newLang })
-  }
-
   render() {
     return (
-      <IntlProvider locale={this.state.lang}>
-        <Router>
-          <div>
-            <Route path="/" component={GoogleAnalyticsPageView} />
-            <Route path={`/:lang?`}
-              render={(props) => {
-                return (
-                  <div>
-                    <section>
-                      <LanguageSelectBanner {...props}
-                        updateLanguage={this.handleLanguageUpdate}
-                      />
-                      <Header {...props} />
-                    </section>
-                    <section className="coa-main">
-                      <Routes/>
-                    </section>
-                    <Footer />
-                  </div>
-                )
-              }}
-            />
-          </div>
-        </Router>
-      </IntlProvider>
+      <Router>
+        <div>
+          <Route path="/" component={GoogleAnalyticsPageView} />
+          <Route path={`/:lang?`}
+            render={(props) => {
+              return (
+                <LanguageWrapper {...props}
+                  urlPathLanguage={props.match.params.lang}
+                />
+              )
+            }}
+          />
+        </div>
+      </Router>
     );
   }
 }

--- a/src/js/components/LanguageWrapper.js
+++ b/src/js/components/LanguageWrapper.js
@@ -1,0 +1,99 @@
+import React, { Component } from 'react'
+import { Router, Route, Switch } from 'react-static'
+import Routes from 'react-static-routes'
+import { IntlProvider } from 'react-intl'
+import locale from 'browser-locale'
+import Cookies from 'js-cookie'
+
+// page_sections
+import LanguageSelectBanner from "js/page_sections/LanguageSelectBanner"
+import Header from "js/page_sections/Header"
+import Footer from "js/page_sections/Footer"
+
+import { SUPPORTED_LANGUAGES } from 'js/constants/languages'
+
+
+
+class LanguageWrapper extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      lang: this.setLanguage()
+    }
+    this.daysUntilCookieExpires = 10 * 365;
+  }
+
+  parseBrowserLanguageCode = () => {
+    // Normally, we only want the two letter lowercased language abbreviation
+    // bc we aren't worried about locale (ex: en-US vs. en-UK) at this point,
+    // just language.
+    const twoLetterLangCode = locale().split('-')[0].toLowerCase();
+    // But we do want to support two types of Chinese (zh-tw & zh-cn)
+    const isChinese = twoLetterLangCode === 'zh';
+    return isChinese ? locale().toLowerCase() : twoLetterLangCode;
+  }
+
+  setLanguage = () => {
+    const cookieLanguage = Cookies.get('lang');
+    const browserLocale = this.parseBrowserLanguageCode();
+    let language = '';
+
+    const isLanguageCodeInPath = SUPPORTED_LANGUAGES
+      .map(lang => lang.code)
+      .includes(this.props.urlPathLanguage)
+
+    if (isLanguageCodeInPath) {
+      language = this.props.urlPathLanguage
+    } else if (cookieLanguage) {
+      language = cookieLanguage
+    } else {
+      language = browserLocale || 'en'
+    }
+
+    Cookies.set('lang', language, { expires: this.daysUntilCookieExpires })
+    return language
+  }
+
+  handleLanguageUpdate = (newLang) => {
+    Cookies.set('lang', newLang, { expires: this.daysUntilCookieExpires })
+    this.setState({ lang: newLang })
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    const isLanguageChanged = nextState.lang !== this.state.lang
+    if (isLanguageChanged) return true;
+    return false;
+  }
+
+  render() {
+    return (
+      <IntlProvider locale={this.state.lang}>
+        <Router>
+          <div>
+            <Route path={`/:lang?`}
+              render={(props) => {
+                return (
+                  <div>
+                    <section>
+                      <LanguageSelectBanner {...props}
+                        updateLanguage={this.handleLanguageUpdate}
+                      />
+                      <Header {...props} />
+                    </section>
+                    <section className="coa-main">
+                      <Routes/>
+                    </section>
+                    <Footer />
+                  </div>
+                )
+              }}
+            />
+          </div>
+        </Router>
+      </IntlProvider>
+    );
+  }
+
+}
+
+export default LanguageWrapper;


### PR DESCRIPTION
When I ditched the `LanguageWrapper` component I broke some important functionality. @ifsimicoded, thanks for catching that and being persistent in explaining to me, the dunce. 💜https://github.com/cityofaustin/janis/pull/128#discussion_r165798135

This PR should put things back to how the were mostly. With a "clean" `App.js` and a `LanguageWrapper` that has all the i18n language switch and cookie setting logic.

I did leave Google Analytics in App.js since it feels like a separate concern outside of languages. That didn't seem to effect functionality, but please call me out when I'm wrong. 😄



