### PR TITLE
More Language Code In Links

### DIFF
--- a/src/js/components/LanguageWrapper.js
+++ b/src/js/components/LanguageWrapper.js
@@ -3,6 +3,7 @@ import Routes from 'react-static-routes'
 import { IntlProvider } from 'react-intl'
 import locale from 'browser-locale'
 import Cookies from 'js-cookie'
+import PropTypes from 'prop-types'
 
 // page_sections
 import LanguageSelectBanner from "js/page_sections/LanguageSelectBanner"
@@ -17,6 +18,12 @@ class LanguageWrapper extends Component {
     this.state = {
       lang: this.getInitialLangState()
     }
+  }
+
+  getChildContext() {
+    return {
+      langCode: this.state.lang
+    };
   }
 
   getInitialLangState() {
@@ -98,6 +105,10 @@ class LanguageWrapper extends Component {
       </IntlProvider>
     );
   }
+}
+
+LanguageWrapper.childContextTypes = {
+  langCode: PropTypes.string
 }
 
 export default LanguageWrapper;

--- a/src/js/modules/I18nLink.js
+++ b/src/js/modules/I18nLink.js
@@ -1,11 +1,16 @@
 import React from 'react';
-import { Link, withRouteData } from 'react-static'
+import { Link } from 'react-static'
+import PropTypes from 'prop-types'
 import { i18nalizeLinkTo } from 'js/constants/languages'
 
-const I18nLink = (props) => {
-  const {langCode, to, ...rest} = props;
-  //TO DO -- only pass Link props, not all remaining ...rest
+const I18nLink = (props, context) => {
+  const { to, ...rest } = props;
+  const { langCode } = context;
   return <Link to={i18nalizeLinkTo({to, langCode})} {...rest} />
 }
 
-export default withRouteData(I18nLink);
+I18nLink.contextTypes = {
+  langCode: PropTypes.string,
+}
+
+export default I18nLink;

--- a/src/js/modules/I18nNavLink.js
+++ b/src/js/modules/I18nNavLink.js
@@ -1,11 +1,16 @@
 import React from 'react'
-import { NavLink, withRouteData } from 'react-static'
+import { NavLink } from 'react-static'
+import PropTypes from 'prop-types'
 import { i18nalizeLinkTo } from 'js/constants/languages'
 
-const I18nNavLink = (props) => {
-  const {langCode, to, ...rest} = props;
-  //TO DO -- only pass NavLink props, not all remaining ...rest
+const I18nNavLink = (props, context) => {
+  const { to, ...rest } = props;
+  const { langCode } = context;
   return <NavLink to={i18nalizeLinkTo({to, langCode})} {...rest} />
 }
 
-export default withRouteData(I18nNavLink);
+I18nNavLink.contextTypes = {
+  langCode: PropTypes.string,
+}
+
+export default I18nNavLink;

--- a/static.config.js
+++ b/static.config.js
@@ -78,14 +78,12 @@ export default {
         component: 'src/js/pages/Services',
         getData: async () => ({
           allServices: serviceQueries[langCode],
-          langCode: langCode,
         }),
         children: serviceQueries[langCode].edges.map(({node: service}) => ({
           path: `/${service.slug}`,
           component: 'src/js/pages/Service',
           getData: async () => ({
             service: service,
-            langCode: langCode,
           }),
         })),
       },
@@ -94,14 +92,12 @@ export default {
         component: 'src/js/pages/Topics',
         getData: async () => ({
           allTopics: topicQueries[langCode],
-          langCode: langCode,
         }),
         children: topicQueries[langCode].edges.map(({node:topic}) => ({
           path: `/${topic.id}`,
           component: 'src/js/pages/Topic',
           getData: async () => ({
             topic: topic,
-            langCode: langCode,
           })
         }))
       },
@@ -110,14 +106,12 @@ export default {
         component: 'src/js/pages/Departments',
         getData: async () => ({
           allDepartments: departmentQueries[langCode],
-          langCode: langCode,
         }),
         children: departmentQueries[langCode].edges.map(({node:department}) => ({
           path: `${department.id}`,
           component: 'src/js/pages/Department',
           getData: async () => ({
             department: department,
-            langCode: langCode,
           })
         }))
       },
@@ -142,7 +136,6 @@ export default {
         component: 'src/js/pages/Home',
         children: allPages('en'),
         getData: async () => ({
-          langCode: "en",
           topServices,
         }),
       },
@@ -151,7 +144,6 @@ export default {
         component: 'src/js/pages/Home',
         children: allPages('es'),
         getData: async () => ({
-          langCode: "es",
           topServices: topServices_es,
         }),
       },
@@ -160,7 +152,6 @@ export default {
         component: 'src/js/pages/Home',
         children: allPages('vi'),
         getData: async () => ({
-          langCode: "vi",
           topServices: topServices_vi,
         }),
       },
@@ -169,7 +160,6 @@ export default {
         component: 'src/js/pages/Home',
         children: allPages('ar'),
         getData: async () => ({
-          langCode: "ar",
           topServices: topServices_ar,
         }),
       },


### PR DESCRIPTION
I simplified how language code was handled -- instead of passing language (and a bunch of unnecessary data) through react static RouteData props I'm utilizing context to pass ONLY langCode from parent (LanguageWrapper) to children (I18nLink and I18nNavLink components).

This will close #162 and also is more react-static neutral and hopefully usable when we toss that for another SSR library.