### PR TITLE
Use different defaults in Dockerfile

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -17,20 +17,19 @@ COPY static.config.js /app/static.config.js
 COPY .babelrc /app/.babelrc
 
 ARG GOOGLE_ANALYTICS
-ENV GOOGLE_ANALYTICS=${GOOGLE_ANALYTICS}
+ENV GOOGLE_ANALYTICS=${GOOGLE_ANALYTICS:-UA-110716917-2}
 
 ARG FEEDBACK_API
-ENV FEEDBACK_API=${FEEDBACK_API}
+ENV FEEDBACK_API=${FEEDBACK_API:-https://coa-test-form-api.herokuapp.com/process/}
 
 ARG CMS_API
-ENV CMS_API=${CMS_API}
+ENV CMS_API=${CMS_API:-https://joplin-staging.herokuapp.com/api/graphql}
 
 ARG CMS_MEDIA
-ENV CMS_MEDIA=${CMS_MEDIA}
+ENV CMS_MEDIA=${CMS_MEDIA:-https://joplin-staging.herokuapp.com/media}
 
 COPY public /app/public
 COPY src /app/src
-RUN printenv
 RUN yarn build
 
 # ============================================

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -17,19 +17,20 @@ COPY static.config.js /app/static.config.js
 COPY .babelrc /app/.babelrc
 
 ARG GOOGLE_ANALYTICS
-ENV GOOGLE_ANALYTICS=${GOOGLE_ANALYTICS:-UA-110716917-2}
+ENV GOOGLE_ANALYTICS=${GOOGLE_ANALYTICS}
 
 ARG FEEDBACK_API
-ENV FEEDBACK_API=${FEEDBACK_API:-https://coa-test-form-api.herokuapp.com/process/}
+ENV FEEDBACK_API=${FEEDBACK_API}
 
 ARG CMS_API
-ENV CMS_API=${CMS_API:-https://joplin.herokuapp.com/api/graphql/}
+ENV CMS_API=${CMS_API}
 
 ARG CMS_MEDIA
-ENV CMS_MEDIA=${CMS_MEDIA:-https://joplin.herokuapp.com/media/}
+ENV CMS_MEDIA=${CMS_MEDIA}
 
 COPY public /app/public
 COPY src /app/src
+RUN printenv
 RUN yarn build
 
 # ============================================

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,8 +9,8 @@ CMS_URL=${CMS_URL:-http://$HOST_IP:8000}
 echo "Building image..."
 docker build \
     --rm \
-    --build-arg "CMS_API=$CMS_URL/api/graphql/" \
-    --build-arg "CMS_MEDIA=$CMS_URL/media/" \
+    --build-arg "CMS_API=$CMS_URL/api/graphql" \
+    --build-arg "CMS_MEDIA=$CMS_URL/media" \
     --build-arg "FEEDBACK_API=https://coa-test-form-api.herokuapp.com/process/" \
     --build-arg "GOOGLE_ANALYTICS=UA-110716917-2" \
     --tag "$TAG" \

--- a/scripts/serve-local.sh
+++ b/scripts/serve-local.sh
@@ -23,6 +23,6 @@ docker run \
     --volume "$PWD/.babelrc:/app/.babelrc" \
     --env "GOOGLE_ANALYTICS=UA-110716917-2" \
     --env "FEEDBACK_API=https://coa-test-form-api.herokuapp.com/process/" \
-    --env "CMS_API=http://$HOST_IP:8000/api/graphql/" \
+    --env "CMS_API=http://$HOST_IP:8000/api/graphql" \
     --env "CMS_MEDIA=http://$HOST_IP:8000/media" \
     "$TAG" "$@"


### PR DESCRIPTION
Set the defaults to `joplin-staging` when building. This will be better once we can specify build vars (not runtime environment vars) like specified in cityofaustin/techstack#201

Also, standardized on not including trailing slashes in CMS URLs