### PR TITLE
Right to left (rtl) to language wrapper

### DIFF
--- a/src/css/modules/_ContactDetails.scss
+++ b/src/css/modules/_ContactDetails.scss
@@ -50,3 +50,12 @@
     border: none;
   }
 }
+
+.rtl {
+  .coa-ContactDetails__item {
+    & > :first-child {
+      margin-right: 0;
+      margin-left: $coa-spacing-large;
+    }
+  }  
+}

--- a/src/css/modules/_ContactDetails.scss
+++ b/src/css/modules/_ContactDetails.scss
@@ -51,11 +51,11 @@
   }
 }
 
-.rtl {
+.coa-rtl {
   .coa-ContactDetails__item {
     & > :first-child {
       margin-right: 0;
       margin-left: $coa-spacing-large;
     }
-  }  
+  }
 }

--- a/src/css/modules/_ExternalLink.scss
+++ b/src/css/modules/_ExternalLink.scss
@@ -11,3 +11,12 @@
     }
   };
 }
+
+.rtl {
+  .coa-ExternalLink {
+    svg {
+      margin-right: $coa-space-level1;
+      margin-left: 0;
+    }
+  }
+}

--- a/src/css/modules/_ExternalLink.scss
+++ b/src/css/modules/_ExternalLink.scss
@@ -12,7 +12,7 @@
   };
 }
 
-.rtl {
+.coa-rtl {
   .coa-ExternalLink {
     svg {
       margin-right: $coa-space-level1;

--- a/src/css/modules/_PageBreadcrumbs.scss
+++ b/src/css/modules/_PageBreadcrumbs.scss
@@ -59,7 +59,7 @@
     direction: rtl;
     display: flex;
     flex-direction: row-reverse;
-    justify-content: flex-end;
+    justify-content: center;
     a {
       &:before {
         content: ">";

--- a/src/css/modules/_PageBreadcrumbs.scss
+++ b/src/css/modules/_PageBreadcrumbs.scss
@@ -53,3 +53,31 @@
     }
   }
 }
+
+.rtl {
+  .coa-PageBreadcrumbs {
+    direction: rtl;
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: flex-end;
+    a {
+      &:before {
+        content: ">";
+        padding-left: $coa-spacing-small;
+        padding-right: 0;
+      }
+    }
+  }
+  .coa-PageBreadcrumbs__title:before {
+    content: "";
+  }
+  @include media($coa-large-screen) {
+    &.coa-PageBreadcrumbs__home {
+      display: inline;
+      &:before {
+        content: "";
+        padding-right: 0;
+      }
+    }
+  }
+}

--- a/src/css/modules/_PageBreadcrumbs.scss
+++ b/src/css/modules/_PageBreadcrumbs.scss
@@ -1,8 +1,10 @@
 .coa-PageBreadcrumbs {
   border-bottom: 1px dashed $coa-color-gray;
+  display: flex;
   font-family: $coa-font-sans;
   font-size: $coa-font-size-xsmall;
   font-weight: $coa-font-semibold;
+  justify-content: center;
   line-height: $coa-line-height-xlarge;
   overflow: hidden;
   text-transform: uppercase;
@@ -54,12 +56,10 @@
   }
 }
 
-.rtl {
+.coa-rtl {
   .coa-PageBreadcrumbs {
     direction: rtl;
-    display: flex;
     flex-direction: row-reverse;
-    justify-content: center;
     a {
       &:before {
         content: ">";

--- a/src/css/modules/_Steps.scss
+++ b/src/css/modules/_Steps.scss
@@ -10,7 +10,7 @@
   text-align: center;
 }
 
-.rtl {
+.coa-rtl {
   .coa-Steps__list > ul > li {
     &:before {
       margin-left: $coa-space-level3;

--- a/src/css/modules/_Steps.scss
+++ b/src/css/modules/_Steps.scss
@@ -10,6 +10,15 @@
   text-align: center;
 }
 
+.rtl {
+  .coa-Steps__list > ul > li {
+    &:before {
+      margin-left: $coa-space-level3;
+      margin-right: 0;
+    }
+  }
+}
+
 .coa-Steps__list {
   & > ul {
     counter-reset: step-item;

--- a/src/css/page_sections/Menu/_Menu.scss
+++ b/src/css/page_sections/Menu/_Menu.scss
@@ -45,14 +45,14 @@
 .coa-Menu__mobile-footer {
   padding: $coa-space-level2;
 }
+
 .coa-Menu__footer-text {
   padding: $coa-space-level3 0;
   font-size: $coa-font-size-xsmall;
 }
 
 .coa-Menu__overlay {
-  position: absolute;
-  background: green;
+  position: fixed;
   width: 100%;
   height: 100%;
   z-index: 1;

--- a/src/css/page_sections/Menu/_MenuItem.scss
+++ b/src/css/page_sections/Menu/_MenuItem.scss
@@ -12,7 +12,7 @@
   }
   @include media($coa-large-screen) {
     border: 1px solid transparent;
-    padding: $coa-space-level4 $coa-space-level2 $coa-space-level3;
+    padding: $coa-space-level2 $coa-space-level2 $coa-space-level3;
 
   }
   > a {

--- a/src/css/page_sections/Menu/_MenuItem.scss
+++ b/src/css/page_sections/Menu/_MenuItem.scss
@@ -98,7 +98,7 @@
 }
 
 .coa-MenuItem__arrow-down {
-  margin-left: $coa-space-level1;
+  margin: 0 $coa-space-level1;
 }
 
 .coa-MenuItem__plus-sign {

--- a/src/css/page_sections/Menu/_SubmenuItem.scss
+++ b/src/css/page_sections/Menu/_SubmenuItem.scss
@@ -34,7 +34,7 @@
 }
 
 .coa-SubmenuItem__arrow-right {
-  margin-left: $coa-space-level2;
+  margin: 0 $coa-space-level2;
 }
 
 .coa-SubmenuItem--coming-soon-message {

--- a/src/css/page_sections/_Header.scss
+++ b/src/css/page_sections/_Header.scss
@@ -16,7 +16,7 @@
   border-right: 1px solid $coa-color-purple-lighter;
 }
 
-.rtl {
+.coa-rtl {
   .coa-Header__menu {
     padding: $coa-space-level3 0 $coa-space-level3 $coa-space-level3;
     border-right: none;

--- a/src/css/page_sections/_Header.scss
+++ b/src/css/page_sections/_Header.scss
@@ -16,6 +16,14 @@
   border-right: 1px solid $coa-color-purple-lighter;
 }
 
+.rtl {
+  .coa-Header__menu {
+    padding: $coa-space-level3 0 $coa-space-level3 $coa-space-level3;
+    border-right: none;
+    border-left: 1px solid $coa-color-purple-lighter;
+  }
+}
+
 .coa-Header__logo {
   padding: $coa-space-level3;
   font-family: $coa-font-sans;

--- a/src/js/components/LanguageWrapper.js
+++ b/src/js/components/LanguageWrapper.js
@@ -111,11 +111,11 @@ class LanguageWrapper extends Component {
     const { lang } = this.state;
     const messages = localeMessages[lang];
     // Right to Left Direction for arabic text
-    const direction = lang === 'ar' ? 'rtl' : 'auto';
+    const direction = lang === 'ar' ? 'rtl' : 'ltr';
 
     return (
       <IntlProvider locale={lang} messages={messages} defaultLocale={DEFAULT_LANG} key={lang}>
-        <div style={{ position: 'relative' }} dir={direction}>
+        <div style={{ position: 'relative' }} dir={direction} className={direction}>
           <a href="#main" className="usa-skipnav">Skip to main content</a>
           <LanguageSelectBar lang={lang} path={this.props.match.params.path || ''}/>
           <Header />

--- a/src/js/components/LanguageWrapper.js
+++ b/src/js/components/LanguageWrapper.js
@@ -3,6 +3,8 @@ import Routes from 'react-static-routes'
 import locale from 'browser-locale'
 import Cookies from 'js-cookie'
 import PropTypes from 'prop-types'
+import { find } from 'lodash';
+
 
 // react-intl i18n
 import { IntlProvider, addLocaleData } from 'react-intl'
@@ -14,7 +16,7 @@ import messages_en from 'js/i18n/locales/en.json';
 import messages_es from 'js/i18n/locales/es.json';
 import messages_vi from 'js/i18n/locales/vi.json';
 import messages_ar from 'js/i18n/locales/ar.json';
-import { SUPPORTED_LANG_CODES, LANG_COOKIE_NAME, LANG_COOKIE_EXPIRES, DEFAULT_LANG } from 'js/i18n/constants'
+import { SUPPORTED_LANGUAGES, SUPPORTED_LANG_CODES, LANG_COOKIE_NAME, LANG_COOKIE_EXPIRES, DEFAULT_LANG } from 'js/i18n/constants'
 addLocaleData([...en, ...es, ...vi, ...ar]);
 const localeMessages = {
   'en': messages_en,
@@ -107,15 +109,19 @@ class LanguageWrapper extends Component {
     if(lang && lang !== this.state.lang) this.setState({lang: lang});
   }
 
+  getDirectionFromLanguage(lang) {
+    const currentLangObject = find(SUPPORTED_LANGUAGES, {'code': lang});
+    return currentLangObject.direction;
+  }
+
   render() {
     const { lang } = this.state;
     const messages = localeMessages[lang];
-    // Right to Left Direction for arabic text
-    const direction = lang === 'ar' ? 'rtl' : 'ltr';
+    const direction = this.getDirectionFromLanguage(lang);
 
     return (
       <IntlProvider locale={lang} messages={messages} defaultLocale={DEFAULT_LANG} key={lang}>
-        <div style={{ position: 'relative' }} dir={direction} className={direction}>
+        <div style={{ position: 'relative' }} dir={direction} className={`coa-${direction}`}>
           <a href="#main" className="usa-skipnav">Skip to main content</a>
           <LanguageSelectBar lang={lang} path={this.props.match.params.path || ''}/>
           <Header />

--- a/src/js/components/LanguageWrapper.js
+++ b/src/js/components/LanguageWrapper.js
@@ -110,10 +110,12 @@ class LanguageWrapper extends Component {
   render() {
     const { lang } = this.state;
     const messages = localeMessages[lang];
+    // Right to Left Direction for arabic text
+    const direction = lang === 'ar' ? 'rtl' : 'auto';
 
     return (
       <IntlProvider locale={lang} messages={messages} defaultLocale={DEFAULT_LANG} key={lang}>
-        <div style={{ position: 'relative' }}>
+        <div style={{ position: 'relative' }} dir={direction}>
           <a href="#main" className="usa-skipnav">Skip to main content</a>
           <LanguageSelectBar lang={lang} path={this.props.match.params.path || ''}/>
           <Header />

--- a/src/js/i18n/constants.js
+++ b/src/js/i18n/constants.js
@@ -3,21 +3,25 @@ export const SUPPORTED_LANGUAGES = [
     title: 'English',
     abbr: 'en',
     code: 'en',
+    direction: 'ltr',
   },
   { // Spanish
     title: 'Español',
     abbr: 'es',
     code: 'es',
+    direction: 'ltr',
   },
   { // Vietnamese
     title: 'Tiếng Việt',
     abbr: 'vi',
     code: 'vi',
+    direction: 'ltr',
   },
   { // Arabic
     title: 'العربية',
     abbr: 'ar',
     code: 'ar',
+    direction: 'rtl',
   },
   //   // Simplified Chinese
   //   title: '简体中文',

--- a/src/js/i18n/locales/ar.json
+++ b/src/js/i18n/locales/ar.json
@@ -25,7 +25,6 @@
   "Menu.ThreeOneOneMobileListItem.callText": "Call 311",
   "Menu.ThreeOneOneMobileListItem.onlineText": "Submit an Online Request",
   "Menu.PrivacyPolicyListItem.text": "Read About Privacy",
-  "Menu.MobileFooter.text": "Alpha.austin.gov هو موقع إلكتروني جديد والعمل قيد التنفيذ. للحصول على كامل موقع مدينة أوستن، قم بزيارة {citySiteLink}. تعرف على المزيد حول الموقع الإلكتروني الجديد عبر {citySiteLink}.",
   "Menu.MobileFooter.sealAltText": "City of Austin Seal",
   "ThreeOneOne.sectiontitle.call": "Call 311",
   "ThreeOneOne.sectiontitle.or": "or",
@@ -35,5 +34,5 @@
   "Service.RelatedLinks.SectionHeader": "الاطلاع على الخدمات ذات الصلة",
   "Service.RelatedLinks.Tag": "الخدمة",
   "Home.RelatedLinks.Tag": "الخدمة",
-  "Submenu.workInProgress": "Alpha.austin.gov هو موقع إلكتروني جديد والعمل قيد التنفيذ. للحصول على كامل موقع مدينة أوستن، قم بزيارة {citySiteLink}. تعرف على المزيد حول الموقع الإلكتروني الجديد عبر {citySiteLink}."
+  "Submenu.workInProgress": "Alpha.austin.gov هو موقع إلكتروني جديد والعمل قيد التنفيذ. للحصول على كامل موقع مدينة أوستن، قم بزيارة {citySiteLink}."
 }

--- a/src/js/i18n/locales/ar.json
+++ b/src/js/i18n/locales/ar.json
@@ -25,7 +25,7 @@
   "Menu.ThreeOneOneMobileListItem.callText": "Call 311",
   "Menu.ThreeOneOneMobileListItem.onlineText": "Submit an Online Request",
   "Menu.PrivacyPolicyListItem.text": "Read About Privacy",
-  "Menu.MobileFooter.text": "Alpha.austin.gov is a work in progress. For the full City of Austin website, visit",
+  "Menu.MobileFooter.text": "Alpha.austin.gov هو موقع إلكتروني جديد والعمل قيد التنفيذ. للحصول على كامل موقع مدينة أوستن، قم بزيارة {citySiteLink}. تعرف على المزيد حول الموقع الإلكتروني الجديد عبر {citySiteLink}.",
   "Menu.MobileFooter.sealAltText": "City of Austin Seal",
   "ThreeOneOne.sectiontitle.call": "Call 311",
   "ThreeOneOne.sectiontitle.or": "or",

--- a/src/js/i18n/locales/ar.json
+++ b/src/js/i18n/locales/ar.json
@@ -34,5 +34,6 @@
   "Home.Secondarycontent.bodytext": "Alpha.austin.gov هو موقع إلكتروني جديد والعمل قيد التنفيذ. للحصول على كامل موقع مدينة أوستن، قم بزيارة {citySiteLink}. تعرف على المزيد حول الموقع الإلكتروني الجديد عبر {projectsSiteLink}.",
   "Service.RelatedLinks.SectionHeader": "الاطلاع على الخدمات ذات الصلة",
   "Service.RelatedLinks.Tag": "الخدمة",
-  "Home.RelatedLinks.Tag": "الخدمة"
+  "Home.RelatedLinks.Tag": "الخدمة",
+  "Submenu.workInProgress": "Alpha.austin.gov هو موقع إلكتروني جديد والعمل قيد التنفيذ. للحصول على كامل موقع مدينة أوستن، قم بزيارة {citySiteLink}. تعرف على المزيد حول الموقع الإلكتروني الجديد عبر {citySiteLink}."
 }

--- a/src/js/i18n/locales/en.json
+++ b/src/js/i18n/locales/en.json
@@ -25,7 +25,6 @@
   "Menu.ThreeOneOneMobileListItem.callText": "Call 311",
   "Menu.ThreeOneOneMobileListItem.onlineText": "Submit an Online Request",
   "Menu.PrivacyPolicyListItem.text": "Read About Privacy",
-  "Menu.MobileFooter.text": "Alpha.austin.gov is a work in progress. For the full City of Austin website, visit {citySiteLink}.",
   "Menu.MobileFooter.sealAltText": "City of Austin Seal",
   "ThreeOneOne.sectiontitle.call": "Call 311",
   "ThreeOneOne.sectiontitle.or": "or",

--- a/src/js/i18n/locales/en.json
+++ b/src/js/i18n/locales/en.json
@@ -34,5 +34,6 @@
   "Home.Secondarycontent.bodytext": "Alpha.austin.gov is a new website and a work in progress. For the full City of Austin website, visit  {citySiteLink}. Learn more about the new website at {projectsSiteLink}.",
   "Service.RelatedLinks.SectionHeader": "Check out related services",
   "Service.RelatedLinks.Tag": "Service",
-  "Home.RelatedLinks.Tag": "Service"
+  "Home.RelatedLinks.Tag": "Service",
+  "Submenu.workInProgress": "Alpha.austin.gov is a work in progress. For the full City of Austin website, visit {citySiteLink}."
 }

--- a/src/js/i18n/locales/en.json
+++ b/src/js/i18n/locales/en.json
@@ -25,7 +25,7 @@
   "Menu.ThreeOneOneMobileListItem.callText": "Call 311",
   "Menu.ThreeOneOneMobileListItem.onlineText": "Submit an Online Request",
   "Menu.PrivacyPolicyListItem.text": "Read About Privacy",
-  "Menu.MobileFooter.text": "Alpha.austin.gov is a work in progress. For the full City of Austin website, visit",
+  "Menu.MobileFooter.text": "Alpha.austin.gov is a work in progress. For the full City of Austin website, visit {citySiteLink}.",
   "Menu.MobileFooter.sealAltText": "City of Austin Seal",
   "ThreeOneOne.sectiontitle.call": "Call 311",
   "ThreeOneOne.sectiontitle.or": "or",

--- a/src/js/i18n/locales/es.json
+++ b/src/js/i18n/locales/es.json
@@ -25,7 +25,6 @@
   "Menu.ThreeOneOneMobileListItem.callText": "Call 311",
   "Menu.ThreeOneOneMobileListItem.onlineText": "Submit an Online Request",
   "Menu.PrivacyPolicyListItem.text": "Read About Privacy",
-  "Menu.MobileFooter.text": "Alpha.austin.gov is a work in progress. For the full City of Austin website, visit",
   "Menu.MobileFooter.sealAltText": "City of Austin Seal",
   "ThreeOneOne.sectiontitle.call": "Call 311",
   "ThreeOneOne.sectiontitle.or": "or",
@@ -34,5 +33,6 @@
   "Home.Secondarycontent.bodytext": "Alpha.austin.gov es un sitio web nuevo aún en desarrollo. Para ver el sitio web completo de la Ciudad de Austin, visite {citySiteLink}. Aprenda más sobre el sitio web nuevo en {projectsSiteLink}.",
   "Service.RelatedLinks.SectionHeader": "Vea los servicios relacionados",
   "Service.RelatedLinks.Tag": "servicio",
-  "Home.RelatedLinks.Tag": "servicio"
+  "Home.RelatedLinks.Tag": "servicio",
+  "Submenu.workInProgress": "Alpha.austin.gov es aún en desarrollo. Para ver el sitio web completo de la Ciudad de Austin, visite {citySiteLink}."
 }

--- a/src/js/i18n/locales/vi.json
+++ b/src/js/i18n/locales/vi.json
@@ -25,7 +25,6 @@
   "Menu.ThreeOneOneMobileListItem.callText": "Call 311",
   "Menu.ThreeOneOneMobileListItem.onlineText": "Submit an Online Request",
   "Menu.PrivacyPolicyListItem.text": "Read About Privacy",
-  "Menu.MobileFooter.text": "Alpha.austin.gov is a work in progress. For the full City of Austin website, visit",
   "Menu.MobileFooter.sealAltText": "City of Austin Seal",
   "ThreeOneOne.sectiontitle.call": "Call 311",
   "ThreeOneOne.sectiontitle.or": "or",
@@ -34,5 +33,6 @@
   "Home.Secondarycontent.bodytext": "Alpha.austin.gov là một mạng trực tuyến mới và đang trong thời kỳ khai triển. Để vào mạng đã hoàn tất của Thành phố Austin, xin vào {citySiteLink}. Tìm hiểu thêm về mạng mới tại {projectsSiteLink}.",
   "Service.RelatedLinks.SectionHeader": "Kiểm điểm các dịch vụ liên quan",
   "Service.RelatedLinks.Tag": "Dịch vụ",
-  "Home.RelatedLinks.Tag": "Dịch vụ"
+  "Home.RelatedLinks.Tag": "Dịch vụ",
+  "Submenu.workInProgress": "Alpha.austin.gov là một mạng trực tuyến mới và đang trong thời kỳ khai triển. Để vào mạng đã hoàn tất của Thành phố Austin, xin vào {citySiteLink}."
 }

--- a/src/js/page_sections/Menu/Menu.js
+++ b/src/js/page_sections/Menu/Menu.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { defineMessages, injectIntl } from 'react-intl';
+import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types'
 
 import I18nNavLink from 'js/modules/I18nNavLink';
@@ -41,10 +41,6 @@ const i18nMessages = defineMessages({
   privacy: {
     id: 'Menu.PrivacyPolicyListItem.text',
     defaultMessage: 'Read About Privacy',
-  },
-  footer: {
-    id: 'Menu.MobileFooter.text',
-    defaultMessage: 'Alpha.austin.gov is a work in progress. For the full City of Austin website, visit ',
   },
   sealAltText: {
     id: 'Menu.MobileFooter.sealAltText',
@@ -175,7 +171,13 @@ const PrivacyPolicyListItem = ({intl}) => (
 const MobileFooter = ({intl}) => (
   <div className="coa-Menu__mobile-footer">
     <p className="coa-Menu__footer-text d-lg-none">
-      {intl.formatMessage(i18nMessages.footer)}<ExternalLink to="https://austintexas.gov">austintexas.gov</ExternalLink>.
+      <FormattedMessage
+        id="Menu.MobileFooter.text"
+        defaultMessage="Alpha.austin.gov is a work in progress. For the full City of Austin website, visit {citySiteLink}."
+        values={{
+          citySiteLink: <ExternalLink to="http://austintexas.gov">austintexas.gov</ExternalLink>
+        }}
+      />
     </p>
     <img className="d-lg-none" src={citySealImg} alt={intl.formatMessage(i18nMessages.sealAltText)} />
   </div>

--- a/src/js/page_sections/Menu/Menu.js
+++ b/src/js/page_sections/Menu/Menu.js
@@ -108,6 +108,7 @@ class Menu extends Component {
               theme={theme}
               handleMenuToggle={this.props.toggleMenu}
               handleSublistToggle={this.toggleSublist}
+              intl={intl}
             />
           ))
         }

--- a/src/js/page_sections/Menu/Menu.js
+++ b/src/js/page_sections/Menu/Menu.js
@@ -104,7 +104,6 @@ class Menu extends Component {
               theme={theme}
               handleMenuToggle={this.props.toggleMenu}
               handleSublistToggle={this.toggleSublist}
-              intl={intl}
             />
           ))
         }
@@ -172,10 +171,11 @@ const MobileFooter = ({intl}) => (
   <div className="coa-Menu__mobile-footer">
     <p className="coa-Menu__footer-text d-lg-none">
       <FormattedMessage
-        id="Menu.MobileFooter.text"
-        defaultMessage="Alpha.austin.gov is a work in progress. For the full City of Austin website, visit {citySiteLink}."
-        values={{
-          citySiteLink: <ExternalLink to="http://austintexas.gov">austintexas.gov</ExternalLink>
+        id="Footer.bodytext"
+        defaultMessage="Alpha.austin.gov is a new website and a work in progress. For the full City of Austin website, visit {citySiteLink}. Learn more about the new website at {projectsSiteLink}."
+        values ={{
+          citySiteLink: <ExternalLink to="http://austintexas.gov" iconSize="small">austintexas.gov</ExternalLink>,
+          projectsSiteLink: <ExternalLink to="http://projects.austintexas.io/projects/austin-digital-services-discovery/about/what-we-are-doing/" iconSize="small">projects.austintexas.io</ExternalLink>
         }}
       />
     </p>

--- a/src/js/page_sections/Menu/MenuItem.js
+++ b/src/js/page_sections/Menu/MenuItem.js
@@ -17,7 +17,7 @@ const themeClassnames = (id, theme, openSection) => {
   return `${base} ${openModifier}`;
 }
 
-const MenuItem = ({theme, id, openSection, handleSublistToggle, handleMenuToggle, intl}) => (
+const MenuItem = ({theme, id, openSection, handleSublistToggle, handleMenuToggle}) => (
     <li key={id} className={themeClassnames(id, theme, openSection)}
       aria-expanded={openSection === id}
       aria-haspopup={true}
@@ -40,7 +40,6 @@ const MenuItem = ({theme, id, openSection, handleSublistToggle, handleMenuToggle
           openSection={openSection}
           theme={theme}
           handleMenuToggle={handleMenuToggle}
-          intl={intl}
         />
       )}
     </li>

--- a/src/js/page_sections/Menu/MenuItem.js
+++ b/src/js/page_sections/Menu/MenuItem.js
@@ -17,7 +17,7 @@ const themeClassnames = (id, theme, openSection) => {
   return `${base} ${openModifier}`;
 }
 
-const MenuItem = ({theme, id, openSection, handleSublistToggle, handleMenuToggle}) => (
+const MenuItem = ({theme, id, openSection, handleSublistToggle, handleMenuToggle, intl}) => (
     <li key={id} className={themeClassnames(id, theme, openSection)}
       aria-expanded={openSection === id}
       aria-haspopup={true}
@@ -40,6 +40,7 @@ const MenuItem = ({theme, id, openSection, handleSublistToggle, handleMenuToggle
           openSection={openSection}
           theme={theme}
           handleMenuToggle={handleMenuToggle}
+          intl={intl}
         />
       )}
     </li>

--- a/src/js/page_sections/Menu/Submenu.js
+++ b/src/js/page_sections/Menu/Submenu.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import { defineMessages, injectIntl } from 'react-intl';
 
 import SubmenuItem from 'js/page_sections/Menu/SubmenuItem';
 import ExternalLink from 'js/modules/ExternalLink';
@@ -9,7 +10,9 @@ import ArrowRightSVG from 'js/svg/ArrowRight';
 
 const getSubmenuClassnames = (intl, id, openSection) => {
   const base = 'coa-Submenu';
-  const shouldAlignRight = (intl.locale === 'ar' && id < 5) ||  (intl.locale !== 'ar' && id > 4);
+  const arabicRightMenuItems = intl.locale === 'ar' && id < 5;
+  const nonArabicRightMenuItems = intl.locale !== 'ar' && id > 4;
+  const shouldAlignRight = arabicRightMenuItems ||  nonArabicRightMenuItems;
   const alignRight = shouldAlignRight ? 'coa-Submenu--align-right' : '';
   const open = openSection === id ? 'coa-Submenu--open' : '';
 
@@ -61,4 +64,4 @@ const WorkInProgressSubitem = () => (
   </li>
 )
 
-export default Submenu;
+export default injectIntl(Submenu);

--- a/src/js/page_sections/Menu/Submenu.js
+++ b/src/js/page_sections/Menu/Submenu.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 
 import SubmenuItem from 'js/page_sections/Menu/SubmenuItem';
 import ExternalLink from 'js/modules/ExternalLink';
@@ -50,7 +51,13 @@ const Submenu = ({id, openSection, theme, handleMenuToggle, intl}) => (
 
 const WorkInProgressSubitem = () => (
   <li className="coa-SubmenuItem coa-SubmenuItem--coming-soon-message">
-    Alpha.austin.gov is a work in progress. For the full City of Austin website, visit <ExternalLink to="http://austintexas.gov">austintexas.gov</ExternalLink>.
+    <FormattedMessage
+      id="Submenu.workInProgress"
+      defaultMessage="Alpha.austin.gov is a work in progress. For the full City of Austin website, visit {citySiteLink}."
+      values={{
+        citySiteLink: <ExternalLink to="http://austintexas.gov">austintexas.gov</ExternalLink>
+      }}
+    />
   </li>
 )
 

--- a/src/js/page_sections/Menu/Submenu.js
+++ b/src/js/page_sections/Menu/Submenu.js
@@ -6,11 +6,17 @@ import ExternalLink from 'js/modules/ExternalLink';
 import I18nNavLink from 'js/modules/I18nNavLink';
 import ArrowRightSVG from 'js/svg/ArrowRight';
 
-const Submenu = ({id, openSection, theme, handleMenuToggle}) => (
-  <ul className={`coa-Submenu
-      ${ id > 4 ? `coa-Submenu--align-right` : '' }
-      ${ openSection === id ? 'coa-Submenu--open' : '' }
-    `}
+const getSubmenuClassnames = (intl, id, openSection) => {
+  const base = 'coa-Submenu';
+  const shouldAlignRight = (intl.locale === 'ar' && id < 5) ||  (intl.locale !== 'ar' && id > 4);
+  const alignRight = shouldAlignRight ? 'coa-Submenu--align-right' : '';
+  const open = openSection === id ? 'coa-Submenu--open' : '';
+
+  return `${base} ${alignRight} ${open}`;
+}
+
+const Submenu = ({id, openSection, theme, handleMenuToggle, intl}) => (
+  <ul className={getSubmenuClassnames(intl, id, openSection)}
     id={`topicMenu${id+1}`}
     role="menu"
     aria-labelledby={`theme${id+1}`}

--- a/src/js/page_sections/SecondaryContentBanner.js
+++ b/src/js/page_sections/SecondaryContentBanner.js
@@ -2,12 +2,8 @@ import React from 'react';
 
 const SecondaryContentBanner = ({ children }) => (
   <div className="coa-SecondaryContentBanner">
-    <div className="container-fluid wrapper">
-      <div className="row">
-        <div className="col-sm-10 col-sm-offset-1">
-          {children}
-        </div>
-      </div>
+    <div className="container-fluid wrapper wrapper--sm">
+      {children}
     </div>
   </div>
 );


### PR DESCRIPTION
After doing a bit of research about how this is supposed to work, here is few small change that seem to get the desired effect. Here's some things I learned and some caveats for future refactoring...

- HTML elements can have a `dir` attribute and there is a corresponding CSS rule `direction`. Both use the values `rtl` or `ltr`. In this PR, we use a bit of both. 
  - https://stackoverflow.com/questions/34899513/right-to-left-rtl-support-in-react
  - https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir
  - https://developer.mozilla.org/en-US/docs/Web/CSS/direction

- Additionally, there are some React libraries and CSS tooling for more specialized support. But that doesn't seem necessary at this point, unless usability testing shows otherwise.
  - https://github.com/airbnb/react-with-direction
  - https://cssjanus.github.io/

TODO:

- [x] Breadcrumbs
- [x] Menu dropdown fall offscreen
- [x] translate Menu section about site being a work in progress

![mar-22-2018 19-23-53](https://user-images.githubusercontent.com/5697474/37805204-b2573066-2e06-11e8-8886-11b059c60d2c.gif)

![mar-22-2018 19-24-38](https://user-images.githubusercontent.com/5697474/37805206-b553eed0-2e06-11e8-8f5a-4777555357bc.gif)

_Closes https://github.com/cityofaustin/techstack/issues/145_