### PR TITLE
Topic Breadcrumb updates

### DIFF
--- a/src/__tmpdata/pages.json
+++ b/src/__tmpdata/pages.json
@@ -8,12 +8,8 @@
   },
   "servicepage":{
     "theme": {
-      "title":"Housing and Utilities",
+      "text":"Housing and Utilities",
       "slug":"/themes/housing-and-utilities"
-    },
-    "topic": {
-      "title":"Recycling, trash, and compost",
-      "slug":"/topics/VG9waWNOb2RlOjE="
     }
   },
   "departmentpage": {

--- a/src/js/modules/PageBreadcrumbs.js
+++ b/src/js/modules/PageBreadcrumbs.js
@@ -5,13 +5,13 @@ const PageBreadcrumbs = ({ title, order, ...rest }) => {
 
   const breadcrumbs = order.map(breadcrumb => ({
     className: breadcrumb,
-    title: rest[breadcrumb].title,
-    slug: rest[breadcrumb].slug,
+    text: rest[breadcrumb].text,
+    slug: `/${breadcrumb}s/${rest[breadcrumb].id}`,
   }));
 
   breadcrumbs.unshift({
     className: 'home',
-    title: 'Home',
+    text: 'Home',
     slug: '/',
   });
 
@@ -21,7 +21,7 @@ const PageBreadcrumbs = ({ title, order, ...rest }) => {
       className={`coa-PageBreadcrumbs__${breadcrumb.className}`}
       to={breadcrumb.slug}
     >
-      {breadcrumb.title}
+      {breadcrumb.text}
     </I18nNavLink>
   );
 

--- a/src/js/pages/Service.js
+++ b/src/js/pages/Service.js
@@ -29,11 +29,11 @@ const i18nMessages = defineMessages({
 });
 
 const Service = ({ service, intl }) => {
-  const { image, title, slug, steps, dynamicContent, additionalContent, contacts, related } = service;
+  const { image, title, slug, topic, steps, dynamicContent, additionalContent, contacts, related } = service;
 
   //TODO: data below should be sourced as above
   const { servicepage, services311 } = jsonFileData;
-  const { theme, topic } = servicepage;
+  const { theme } = servicepage;
 
   //TODO: clean data where sourced
   const contact = cleanContacts(contacts)[0];

--- a/src/js/queries/allServicePagesQuery.js
+++ b/src/js/queries/allServicePagesQuery.js
@@ -8,6 +8,7 @@ const allServicePagesQuery = `
           slug
           topic {
             id
+            slug
             text
           }
           steps

--- a/src/js/queries/allTopicPagesQuery.js
+++ b/src/js/queries/allTopicPagesQuery.js
@@ -4,6 +4,7 @@ const allTopicPagesQuery = `
       edges {
         node {
           id,
+          slug,
           text,
           description,
           services {


### PR DESCRIPTION
- use joplin delivered topic data in breadcrumbs to get translated content
- use ids instead of slugs for navigation until slugs are implemented
- add slugs to joplin queries to prep for future slug usage