### PR TITLE
Recollect Tabbing and HashLink

### DIFF
--- a/src/css/modules/_Recollect.scss
+++ b/src/css/modules/_Recollect.scss
@@ -20,6 +20,52 @@
     }
   }
   .widget-body {
+    .widget-nav {
+      display: flex !important;
+      justify-content: space-between;
+      & > li {
+        border: 1px solid transparent;
+        flex-basis: 32%;
+        margin: 0;
+        padding: 10px 0;
+        width: auto;
+        &:nth-child(3) {
+          display: none;
+        }
+        &.active {
+          border-color: $coa-color-gray;
+        }
+        &:hover {
+          background-color:$coa-color-gray-lighter;
+        }
+        & > a {
+          align-items: center;
+          background: none;
+          border: none;
+          border-radius: 0;
+          display: flex;
+          height: 100%;
+          justify-content: center;
+          margin: 0;
+          padding: 6px;
+          &:hover {
+            background: none;
+            border: none;
+          }
+          & > img {
+            display: none;
+          }
+          & > .tab-name {
+            line-height: $coa-line-height-xsmall;
+            font-size: $coa-font-size-xsmall;
+            font-family: $coa-font-sans;
+            font-weight: $coa-font-semibold;
+            margin: 0 0 0 9px;
+            text-transform: uppercase;
+          }
+        }
+      }
+    }
     #rCpage-calendar_search {
       .page-section {
         padding: 0;

--- a/src/js/modules/ApplicationBlock.js
+++ b/src/js/modules/ApplicationBlock.js
@@ -18,11 +18,15 @@ const ApplicationBlock = ({ type, data, intl }) => {
   let app, title;
   switch(type) {
     case "collection_schedule_block":
-      app = <Recollect name="calendar"/>;
+      app = <Recollect options={{name:"calendar"}} />;
       title = intl.formatMessage(i18nMessages.applicationBlockRecollectCalendar);
       break;
     case "what_do_i_do_with_block":
-      app = <Recollect name="wizard"/>;
+      app = <Recollect options={{name:"wizard"}}/>;
+      title = intl.formatMessage(i18nMessages.applicationBlockRecollectWizard);
+      break;
+    case "recollect":
+      app = <Recollect options={{page:"tabbed_widget", name:"wizard"}}/>;
       title = intl.formatMessage(i18nMessages.applicationBlockRecollectWizard);
       break;
     case "map_block":

--- a/src/js/modules/ApplicationBlock.js
+++ b/src/js/modules/ApplicationBlock.js
@@ -14,30 +14,36 @@ const i18nMessages = defineMessages({
   },
 });
 
-const ApplicationBlock = ({ type, data, intl }) => {
-  let app, title;
+const ApplicationBlock = ({ content, intl }) => {
+
+  const { type, value } = content;
+  let app, title, id;
   switch(type) {
     case "collection_schedule_block":
       app = <Recollect options={{name:"calendar"}} />;
       title = intl.formatMessage(i18nMessages.applicationBlockRecollectCalendar);
+      id = "HashLink-Recollect";
       break;
     case "what_do_i_do_with_block":
       app = <Recollect options={{name:"wizard"}}/>;
       title = intl.formatMessage(i18nMessages.applicationBlockRecollectWizard);
+      id = "HashLink-Recollect";
       break;
-    case "recollect":
+    case "recollect_block":
       app = <Recollect options={{page:"tabbed_widget", name:"wizard"}}/>;
       title = intl.formatMessage(i18nMessages.applicationBlockRecollectWizard);
+      id = "HashLink-Recollect";
       break;
     case "map_block":
-      app = <StaticMap title={data.description} location={data.location} />;
-      title = data.description;
+      app = <StaticMap title={value.description} location={value.location} />;
+      title = value.description;
+      id = `HashLink-Map-${content.id}`;
       break;
   }
 
   if (!app) return null;
   return (
-    <div className="coa-ApplicationBlock">
+    <div id={id} className="coa-ApplicationBlock">
       <h2 className="coa-ApplicationBlock__title">{title}</h2>
       {app}
     </div>

--- a/src/js/modules/Recollect.js
+++ b/src/js/modules/Recollect.js
@@ -6,11 +6,11 @@ class Recollect extends Component {
   handleScriptLoad() {
     // Recollect is a third party script that isn't an import-able node module
     // rCw is the required container id to ensure styles are shown correctly
-    let loader = new window.Recollect.Widget.Loader({
-        area: "Austin",
-        name: this.props.name || 'calendar',
-        container: "#rCw"
-      });
+    const options = Object.assign({
+      area: "Austin",
+      container: "#rCw"
+    }, this.props.options);
+    let loader = new window.Recollect.Widget.Loader(options);
     loader.load();;
   }
 

--- a/src/js/pages/Service.js
+++ b/src/js/pages/Service.js
@@ -51,7 +51,7 @@ const Service = ({ service, intl }) => {
 
         { !!dynamicContent && (
           dynamicContent.map(content =>
-            <ApplicationBlock key={content.id} type={content.type} data={content.value} />
+            <ApplicationBlock key={content.id} content={content} />
           )
         )}
 


### PR DESCRIPTION
Added option for Tabbed Recollect -- Joplin data should be formatted as below 

```
"dynamicContent": [
        {
          "id": "a4e532e1-8113-4552-b2ba-4df23c1edbf8",
          "type": "recollect_block",
          "value": null
        },
        ...
]
```
Jump Links to Recollect should look like 
`<a href="#HashLink-Recollect">Go To Recollect</a>`

@cthibaultatx I'm sorry this look horrible. We can style this as you see fit.
![screen shot 2018-03-23 at 9 51 20 pm](https://user-images.githubusercontent.com/3039125/37859610-5d0b5fea-2ee4-11e8-8d1d-08b8f95990e0.png)
