### PR TITLE
breadcrumb translate home

### DIFF
--- a/src/css/page_sections/_LanguageSelectBar.scss
+++ b/src/css/page_sections/_LanguageSelectBar.scss
@@ -18,6 +18,12 @@
   }
 }
 
+.coa-rtl {
+  .coa-LanguageSelectBar__language-list {
+    flex-direction: row-reverse;
+  }
+}
+
 .coa-LanguageSelectBar__language-item {
   color: $coa-color-white;
   cursor: pointer;

--- a/src/js/i18n/locales/ar.json
+++ b/src/js/i18n/locales/ar.json
@@ -20,6 +20,7 @@
   "Header.Menu.button": "Menu",
   "Header.Search.button": "بحث",
   "Header.Airport.text": "المطار",
+  "PageBreadcrumbs.Home.text": "الصفحة الرئيسية",
   "Menu.HomeMobileListItem.text": "الصفحة الرئيسية",
   "Menu.AirportMobileListItem.text": "المطار",
   "Menu.ThreeOneOneMobileListItem.callText": "Call 311",

--- a/src/js/i18n/locales/en.json
+++ b/src/js/i18n/locales/en.json
@@ -20,6 +20,7 @@
   "Header.Menu.button": "Menu",
   "Header.Search.button": "Search",
   "Header.Airport.text": "AIRPORT",
+  "PageBreadcrumbs.Home.text": "Home",
   "Menu.HomeMobileListItem.text": "Home",
   "Menu.AirportMobileListItem.text": "Airport",
   "Menu.ThreeOneOneMobileListItem.callText": "Call 311",

--- a/src/js/i18n/locales/es.json
+++ b/src/js/i18n/locales/es.json
@@ -20,6 +20,7 @@
   "Header.Menu.button": "Menu",
   "Header.Search.button": "Buscar",
   "Header.Airport.text": "AEROPUERTO",
+  "PageBreadcrumbs.Home.text": "Inicio",
   "Menu.HomeMobileListItem.text": "Inicio",
   "Menu.AirportMobileListItem.text": "Aeropuerto",
   "Menu.ThreeOneOneMobileListItem.callText": "Call 311",

--- a/src/js/i18n/locales/vi.json
+++ b/src/js/i18n/locales/vi.json
@@ -20,6 +20,7 @@
   "Header.Menu.button": "Menu",
   "Header.Search.button": "Tra tìm",
   "Header.Airport.text": "PHI TRƯỜNG",
+  "PageBreadcrumbs.Home.text": "Nhà ở",
   "Menu.HomeMobileListItem.text": "Nhà ở",
   "Menu.AirportMobileListItem.text": "Phi trường",
   "Menu.ThreeOneOneMobileListItem.callText": "Call 311",

--- a/src/js/modules/PageBreadcrumbs.js
+++ b/src/js/modules/PageBreadcrumbs.js
@@ -1,7 +1,15 @@
 import React from 'react';
+import { defineMessages, injectIntl } from 'react-intl';
 import I18nNavLink from 'js/modules/I18nNavLink';
 
-const PageBreadcrumbs = ({ title, order, ...rest }) => {
+const PageBreadcrumbs = ({ intl, title, order, ...rest }) => {
+
+  const i18nMessages = defineMessages({
+    home: {
+      id: 'PageBreadcrumbs.Home.text',
+      defaultMessage: 'Home',
+    }
+  });
 
   const breadcrumbs = order.map(breadcrumb => ({
     className: breadcrumb,
@@ -11,7 +19,7 @@ const PageBreadcrumbs = ({ title, order, ...rest }) => {
 
   breadcrumbs.unshift({
     className: 'home',
-    text: 'Home',
+    text: intl.formatMessage(i18nMessages.home),
     slug: '/',
   });
 
@@ -35,4 +43,4 @@ const PageBreadcrumbs = ({ title, order, ...rest }) => {
   );
 }
 
-export default PageBreadcrumbs;
+export default injectIntl(PageBreadcrumbs);


### PR DESCRIPTION
- addresses more of #197 by translating the word 'Home' 
- keeps the language select bar on the right side regardless of rtl or ltr content so transitioning from language to language is easier