### PR TITLE
First shot at build cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,11 @@ ENV NODE_PATH=src
 
 COPY yarn.lock /app/yarn.lock
 COPY package.json /app/package.json
+RUN yarn
 
 COPY intl.buildlangs.js /app/intl.buildlangs.js
 COPY static.config.js /app/static.config.js
 COPY .babelrc /app/.babelrc
-RUN yarn
 
 COPY public /app/public
 COPY src /app/src

--- a/static.config.js
+++ b/static.config.js
@@ -1,5 +1,5 @@
-
 import { GraphQLClient } from 'graphql-request';
+import { SUPPORTED_LANG_CODES } from 'js/i18n/constants';
 
 // QUERIES
 import allServicePagesQuery from 'js/queries/allServicePagesQuery';
@@ -8,210 +8,156 @@ import allDepartmentPagesQuery from 'js/queries/allDepartmentPagesQuery';
 import topServicesQuery from 'js/queries/topServicesQuery';
 import allThemesQuery from 'js/queries/allThemesQuery';
 
-const { CMS_API } = process.env;
+
+const createGraphQLClientsByLang = (lang) => {
+  const { CMS_API } = process.env;
+
+  return new GraphQLClient(CMS_API, {
+    headers: { 'Accept-Language': lang }
+  })
+}
+
+const makeAllPages = async (langCode) => {
+  const path = `/${!!langCode ? langCode : ''}`
+  console.log(`- Building routes for ${path}...`);
+
+  const data = {
+    path: path,
+    component: 'src/js/pages/Home',
+    children: await makeChildPages(langCode),
+    getData: async () => {
+      const client = createGraphQLClientsByLang(langCode);
+      const { allServicePages: topServices } = await client.request(topServicesQuery);
+
+      return {
+        topServices,
+        image: {
+          file: 'original_images/lady-bird-lake.jpg',
+          title: 'Lady Bird Lake walking trail'
+        }
+      };
+    },
+  };
+
+  return data;
+}
+
+const makeChildPages = (langCode) => {
+  const client = createGraphQLClientsByLang(langCode);
+
+  return Promise.all([
+    makeServicePages(client),
+    makeTopicPages(client),
+    makeThemePages(client),
+    makeDepartmentPages(client),
+  ]);
+}
+
+const makeServicePages = async (client) => {
+  const { allServicePages: allServices } = await client.request(allServicePagesQuery);
+
+  const data = {
+    path: '/services',
+    component: 'src/js/pages/Services',
+    getData: async () => ({
+      allServices
+    }),
+    children: allServices.edges.map(({node: service}) => ({
+      path: `/${service.slug}`,
+      component: 'src/js/pages/Service',
+      getData: async () => ({
+        service,
+      }),
+    })),
+  };
+
+  return data;
+}
+
+const makeTopicPages = async (client) => {
+  const { allTopics } = await client.request(allTopicPagesQuery);
+
+  const data = {
+    path: '/topics',
+    component: 'src/js/pages/Topics',
+    getData: async () => ({
+      allTopics,
+    }),
+    children: allTopics.edges.map(({node: topic}) => ({
+      path: `/${topic.slug}`,
+      component: 'src/js/pages/Topic',
+      getData: async () => ({
+        topic,
+      })
+    }))
+  };
+
+  return data;
+}
+
+const makeThemePages = async (client) => {
+  const { allThemes } = await client.request(allThemesQuery);
+
+  const data = {
+    path: '/themes',
+    component: 'src/js/pages/Themes',
+    getData: async () => ({
+      allThemes,
+    }),
+    children: allThemes.edges.map(({node: theme}) => ({
+      path: `/${theme.slug}`,
+      component: 'src/js/pages/Theme',
+      getData: async () => ({
+        theme,
+      })
+    }))
+  };
+
+  return data;
+}
+
+const makeDepartmentPages = async (client) => {
+  const { allDepartments } = await client.request(allDepartmentPagesQuery);
+
+  const data = {
+    path: '/departments',
+    component: 'src/js/pages/Departments',
+    getData: async () => ({
+      allDepartments,
+    }),
+    children: allDepartments.edges.map(({node: department}) => ({
+      path: `${department.id}`,
+      component: 'src/js/pages/Department',
+      getData: async () => ({
+        department,
+      })
+    }))
+  };
+
+  return data;
+}
 
 export default {
   getSiteProps: () => ({
     title: 'City of Austin',
   }),
   getRoutes: async () => {
-    // In order to pass new headers, we have to reintantiate a new
-    // GraphQLClient constructor.
-    // https://github.com/graphcool/graphql-request/issues/33
-    const createGraphQLClientsByLang = async (lang) => {
-      return new GraphQLClient(CMS_API, {
-        headers: { 'Accept-Language': lang }
-      })
-    }
-
-    // TODO: There's a bunch of redundant code that could be cleaned up by
-    // looping through the SUPPORTED_LANGUAGES.
-    const enGraphQLClient = await createGraphQLClientsByLang('en');
-    const esGraphQLClient = await createGraphQLClientsByLang('es');
-    const viGraphQLClient = await createGraphQLClientsByLang('vi');
-    const arGraphQLClient = await createGraphQLClientsByLang('ar');
-
-    const { allServicePages } = await enGraphQLClient.request(allServicePagesQuery)
-    const { allTopics } = await enGraphQLClient.request(allTopicPagesQuery)
-    const { allDepartments } = await enGraphQLClient.request(allDepartmentPagesQuery)
-    const { allServicePages: topServices } = await enGraphQLClient.request(topServicesQuery)
-    const { allThemes } = await enGraphQLClient.request(allThemesQuery)
-
-    const { allServicePages: allServicePages_es } = await esGraphQLClient.request(allServicePagesQuery)
-    const { allTopics: allTopics_es } = await esGraphQLClient.request(allTopicPagesQuery)
-    const { allDepartments: allDepartments_es } = await esGraphQLClient.request(allDepartmentPagesQuery)
-    const { allServicePages: topServices_es } = await esGraphQLClient.request(topServicesQuery)
-    const { allThemes: allThemes_es } = await esGraphQLClient.request(allThemesQuery)
-
-    const { allServicePages: allServicePages_vi } = await viGraphQLClient.request(allServicePagesQuery)
-    const { allTopics: allTopics_vi } = await viGraphQLClient.request(allTopicPagesQuery)
-    const { allDepartments: allDepartments_vi } = await viGraphQLClient.request(allDepartmentPagesQuery)
-    const { allServicePages: topServices_vi } = await viGraphQLClient.request(topServicesQuery)
-    const { allThemes: allThemes_vi } = await viGraphQLClient.request(allThemesQuery)
-
-    const { allServicePages: allServicePages_ar } = await arGraphQLClient.request(allServicePagesQuery)
-    const { allTopics: allTopics_ar } = await arGraphQLClient.request(allTopicPagesQuery)
-    const { allDepartments: allDepartments_ar } = await arGraphQLClient.request(allDepartmentPagesQuery)
-    const { allServicePages: topServices_ar } = await arGraphQLClient.request(topServicesQuery)
-    const { allThemes: allThemes_ar } = await arGraphQLClient.request(allThemesQuery)
-
-    const serviceQueries = {
-      en: allServicePages,
-      es: allServicePages_es,
-      vi: allServicePages_vi,
-      ar: allServicePages_ar,
-    }
-
-    const topicQueries = {
-      en: allTopics,
-      es: allTopics_es,
-      vi: allTopics_vi,
-      ar: allTopics_ar,
-    }
-
-    const departmentQueries = {
-      en: allDepartments,
-      es: allDepartments_es,
-      vi: allDepartments_vi,
-      ar: allDepartments_ar,
-    }
-
-    const themeQueries = {
-      en: allThemes,
-      es: allThemes_es,
-      vi: allThemes_vi,
-      ar: allThemes_ar,
-    }
-
-    const allPages = (langCode = 'en') => {
-      return [{
-        path: '/services',
-        component: 'src/js/pages/Services',
-        getData: async () => ({
-          allServices: serviceQueries[langCode],
-        }),
-        children: serviceQueries[langCode].edges.map(({node: service}) => ({
-          path: `/${service.slug}`,
-          component: 'src/js/pages/Service',
-          getData: async () => ({
-            service: service,
-          }),
-        })),
-      },
-      {
-        path: '/topics',
-        component: 'src/js/pages/Topics',
-        getData: async () => ({
-          allTopics: topicQueries[langCode],
-        }),
-        children: topicQueries[langCode].edges.map(({node:topic}) => ({
-          path: `/${topic.slug}`,
-          component: 'src/js/pages/Topic',
-          getData: async () => ({
-            topic: topic,
-          })
-        }))
-      },
-      {
-        path: '/themes',
-        component: 'src/js/pages/Themes',
-        getData: async () => ({
-          allThemes: themeQueries[langCode],
-        }),
-        children: themeQueries[langCode].edges.map(({node:theme}) => ({
-          path: `/${theme.slug}`,
-          component: 'src/js/pages/Theme',
-          getData: async () => ({
-            theme,
-          })
-        }))
-      },
-      {
-        path: '/departments',
-        component: 'src/js/pages/Departments',
-        getData: async () => ({
-          allDepartments: departmentQueries[langCode],
-        }),
-        children: departmentQueries[langCode].edges.map(({node:department}) => ({
-          path: `${department.id}`,
-          component: 'src/js/pages/Department',
-          getData: async () => ({
-            department: department,
-          })
-        }))
-      },
+    const routes = [
       {
         path: '/search',
         component: 'src/js/pages/Search', //TODO: update search page to be conscious of all languages
-      },
-    ]}
-
-
-    return [
-      ...allPages(),
-      {
-        path: '/',
-        component: 'src/js/pages/Home',
-        getData: async () => ({
-          topServices,
-          image: {
-            file: 'original_images/lady-bird-lake.jpg',
-            title: 'Lady Bird Lake walking trail'
-          }
-        }),
-      },
-      {
-        path: `/en`,
-        component: 'src/js/pages/Home',
-        children: allPages('en'),
-        getData: async () => ({
-          topServices,
-          image: {
-            file: 'original_images/lady-bird-lake.jpg',
-            title: 'Lady Bird Lake walking trail'
-          }
-        }),
-      },
-      {
-        path: `/es`,
-        component: 'src/js/pages/Home',
-        children: allPages('es'),
-        getData: async () => ({
-          topServices: topServices_es,
-          image: {
-            file: 'original_images/lady-bird-lake.jpg',
-            title: 'Lady Bird Lake walking trail in spanish'
-          }
-        }),
-      },
-      {
-        path: `/vi`,
-        component: 'src/js/pages/Home',
-        children: allPages('vi'),
-        getData: async () => ({
-          topServices: topServices_vi,
-          image: {
-            file: 'original_images/lady-bird-lake.jpg',
-            title: 'Lady Bird Lake walking trail in vietnamese'
-          }
-        }),
-      },
-      {
-        path: `/ar`,
-        component: 'src/js/pages/Home',
-        children: allPages('ar'),
-        getData: async () => ({
-          topServices: topServices_ar,
-          image: {
-            file: 'original_images/lady-bird-lake.jpg',
-            title: 'Lady Bird Lake walking trail in arabic'
-          }
-        }),
       },
       {
         is404: true,
         component: 'src/js/pages/404', //TODO: update 404 page to be conscious of all languages
       },
-    ]
+    ];
+
+    const allLangs = Array.from(SUPPORTED_LANG_CODES);
+    allLangs.unshift(undefined);
+    const translatedRoutes = await Promise.all(allLangs.map((langCode) => makeAllPages(langCode)));
+    const allRoutes = routes.concat(translatedRoutes)
+
+    return allRoutes;
   },
 }


### PR DESCRIPTION
Overall consolidated things into being more DRY and consistent across
languages. Each language should be built concurrently.

Things to note

- Previously the English (`/en`) and default (`/`) routes used the same
  query results. Now we'll make separate queries even though they both
  use English translations. This means it'll take a little longer, but
  hopefully other optimizations will make up for it.
- I haven't yet done anything to get navigation info from the API