### PR TITLE
Sd quickfix submenuclicktarget

### DIFF
--- a/src/js/page_sections/Header.js
+++ b/src/js/page_sections/Header.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
 import SearchSVG from 'js/svg/Search';
-import AirplaneSVG from 'js/svg/Airplane';
 import Menu from 'js/page_sections/Menu/Menu';
 import I18nLink from 'js/modules/I18nLink';
 import ExternalLink from 'js/modules/ExternalLink';

--- a/src/js/page_sections/Menu/Menu.js
+++ b/src/js/page_sections/Menu/Menu.js
@@ -131,7 +131,7 @@ class Menu extends Component {
             this provides a full page click target area behind the nav menu
             which, when clicked, will close the submenu
           */
-          !!this.state.openSubmenuId && (
+            this.state.openSubmenuId !== null && (
             <div className="coa-Menu__close-submenu-click-target"
               onClick={() => this.setState({ openSubmenuId: null })}
             ></div>


### PR DESCRIPTION
the click target overlay for submenu's closing didn't show up when the openSubmenuId was 0.