### PR TITLE
Use getSiteData to cleanup build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react-load-script": "^0.0.6",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
-    "react-static": "^5.6.8",
+    "react-static": "^5.7.1",
     "react-universal-component": "^2.8.1",
     "storybook": "^1.0.0",
     "uswds": "^1.4.5"

--- a/src/js/page_sections/Menu/Menu.js
+++ b/src/js/page_sections/Menu/Menu.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
-import { withRouteData } from 'react-static';
+import { withSiteData } from 'react-static';
 import PropTypes from 'prop-types'
 
 import I18nNavLink from 'js/modules/I18nNavLink';
@@ -81,7 +81,7 @@ class Menu extends Component {
   }
 
   render() {
-    const { allThemes } = this.props;
+    const { allThemes } = this.props.navigation[this.props.intl.locale];
 
     return allThemes.edges.length && (
       <div className="container-fluid wrapper">
@@ -192,4 +192,4 @@ const MobileFooter = injectIntl(({intl}) => (
   </div>
 ))
 
-export default withRouteData(Menu);
+export default withSiteData(injectIntl(Menu));


### PR DESCRIPTION
Rather than passing `allThemes` into each route, we can use `getSiteData` to fetch data for all languages and then have the menu fetch out `allThemes` based on the language. This means we can decouple components from the menu.

Based on Simi's brilliant feedback (remember folks: she's always right) https://github.com/cityofaustin/janis/pull/210#discussion_r178567949