### PR TITLE
Update `/services` page

### DIFF
--- a/src/__tmpdata/pages.json
+++ b/src/__tmpdata/pages.json
@@ -2,16 +2,6 @@
   "meta": {},
   "themepage":{},
   "topicpage":{},
-  "servicespage": {
-    "title": "Use City of Austin Services",
-    "body": "<p>The City of Austin provides hundreds of services to people. This is a short list of services that will grow over time.</p>"
-  },
-  "servicepage":{
-    "theme": {
-      "text":"Housing and Utilities",
-      "slug":"/themes/housing-and-utilities"
-    }
-  },
   "departmentpage": {
     "projectsRelated": [
       {

--- a/src/__tmpdata/pages.json
+++ b/src/__tmpdata/pages.json
@@ -1,7 +1,4 @@
 {
-  "meta": {},
-  "themepage":{},
-  "topicpage":{},
   "departmentpage": {
     "projectsRelated": [
       {

--- a/src/js/pages/Services.js
+++ b/src/js/pages/Services.js
@@ -1,39 +1,46 @@
 import React from 'react';
 import { withRouteData } from 'react-static';
+import { defineMessages, injectIntl } from 'react-intl';
 import { get } from 'lodash';
 
-import Hero from 'js/modules/Hero';
+import PageHeader from 'js/modules/PageHeader';
 import TileGroup from 'js/modules/TileGroup';
-import FormFeedback from 'js/page_sections/FormFeedback';
 import ThreeOneOne from 'js/page_sections/ThreeOneOne';
 
 import { cleanServiceLinks } from 'js/helpers/cleanData';
 
 // TODO: this jsonFileData is temporary. Add it to Wagtail API
 import jsonFileData from '__tmpdata/pages';
-const title = get(jsonFileData, "servicespage.title", null);
-const body = get(jsonFileData, "servicespage.body", null);
 const services311 = get(jsonFileData, "services311", null);
 
-const Services = ({ allServices }) => {
+const i18nMessages = defineMessages({
+  servicesPageTitle: {
+    id: 'Services.title',
+    defaultMessage: 'Use City of Austin Services',
+  },
+  servicePageDescription: {
+    id: 'Services.description',
+    defaultMessage: 'The City of Austin provides hundreds of services to people. This is a short list of services that will grow over time.',
+  }
+})
+
+const Services = ({ allServices, intl }) => {
   const relatedLinks = cleanServiceLinks(allServices)
 
   return (
     <div>
-      <div className="wrapper">
-        <Hero callout={title} />
-        <div className="coa-main__body" dangerouslySetInnerHTML={{__html: body}} />
+      <div className="wrapper wrapper--sm container-fluid">
+        <PageHeader
+          title={intl.formatMessage(i18nMessages.servicesPageTitle)}
+          description={intl.formatMessage(i18nMessages.servicePageDescription)}
+        />
       </div>
-      <TileGroup tiles={relatedLinks} />
-      <div className="coa-section coa-section--lightgrey">
-        <div className="wrapper">
-          <FormFeedback />
-          <a className="coa-section__link" href="#">Return to Top</a>
-        </div>
+      <div className="wrapper container-fluid">
+        <TileGroup tiles={relatedLinks} />
+        <ThreeOneOne services311={services311} />
       </div>
-      <ThreeOneOne services311={services311} />
     </div>
   )
 }
 
-export default withRouteData(Services)
+export default withRouteData(injectIntl(Services))


### PR DESCRIPTION
This PR does two things:
1. Update the `/services` page which gets forgotten because its not important, not in the navigation, and not designed in Sketch.
2. Trim down the tmpdata file to remove keys we aren't using no more. Thanks to @benweatherman for calling that out [here](https://github.com/cityofaustin/janis/pull/212#issuecomment-378653816)