### PR TITLE
fix for open menu after clicking submenu link and resizing browser

### DIFF
--- a/src/js/page_sections/Header.js
+++ b/src/js/page_sections/Header.js
@@ -29,13 +29,17 @@ class Header extends Component {
     };
   }
 
-  toggleMenu = (e) => {
-    if (this.state.menuIsOpen) {
-      this.refs.menu.focus();
-    }
+  closeMenu = (e) => {
+    this.refs.menu.focus();
     this.setState({
-      menuIsOpen: !this.state.menuIsOpen,
-    })
+      menuIsOpen: false,
+    });
+  }
+
+  openMenu = (e) => {
+    this.setState({
+      menuIsOpen: true
+    });
   }
 
   render() {
@@ -47,7 +51,7 @@ class Header extends Component {
         <div className="container-fluid wrapper">
           <div className="coa-Header__controls">
             <div className="coa-Header__left-controls">
-              <button onClick={this.toggleMenu} tabIndex="0"
+              <button onClick={this.openMenu} tabIndex="0"
                 className="coa-Header__menu-toggle d-lg-none" ref="menu"
               >
                 {intl.formatMessage(i18nMessages.headerMenuButton)}
@@ -68,7 +72,7 @@ class Header extends Component {
         </div>
         <Menu
           isMenuOpen={this.state.menuIsOpen}
-          toggleMenu={this.toggleMenu}
+          closeMenu={this.closeMenu}
           navigation={navigation}
         />
       </header>

--- a/src/js/page_sections/Menu/Menu.js
+++ b/src/js/page_sections/Menu/Menu.js
@@ -59,8 +59,8 @@ class Menu extends Component {
     this.state.openSubmenuId === id
   )
 
-  toggleAllMenus = (e) => {
-    this.props.toggleMenu();
+  closeAllMenus = (e) => {
+    this.props.closeMenu();
     this.setState({
       openSubmenuId: null
     });
@@ -89,14 +89,14 @@ class Menu extends Component {
           role="navigation"
         >
           <button className="coa-Menu__close-btn d-lg-none"
-            onClick={this.toggleAllMenus}
+            onClick={this.closeAllMenus}
             ref="closeTrigger"
             tabIndex="0"
           >
             <CloseSVG size="40" />
           </button>
           <ul className="coa-Menu__list">
-            <HomeMobileMenuItem handleToggleAllMenus={this.toggleAllMenus} />
+            <HomeMobileMenuItem handleCloseAllMenus={this.closeAllMenus} />
             <AirportMobileMenuItem />
             <ThreeOneOneMobileMenuItem />
         {
@@ -106,12 +106,12 @@ class Menu extends Component {
               id={i}
               theme={theme}
               isSubmenuOpen={this.isSubmenuOpen(i)}
-              handleToggleAllMenus={this.toggleAllMenus}
+              handleCloseAllMenus={this.closeAllMenus}
               handleSubmenuToggle={this.toggleSubmenu}
             />
           ))
         }
-            <PrivacyPolicyMenuItem handleToggleAllMenus={this.toggleAllMenus} />
+            <PrivacyPolicyMenuItem handleCloseAllMenus={this.closeAllMenus} />
             <MobileFooter />
           </ul>
         </nav>
@@ -131,8 +131,8 @@ class Menu extends Component {
   }
 }
 
-const HomeMobileMenuItem = injectIntl(({handleToggleAllMenus, intl}) => (
-  <li className="d-lg-none" onClick={handleToggleAllMenus}>
+const HomeMobileMenuItem = injectIntl(({handleCloseAllMenus, intl}) => (
+  <li className="d-lg-none" onClick={handleCloseAllMenus}>
     <div className="coa-MenuItem coa-MenuItem--small coa-MenuItem--home">
       <I18nNavLink to="/" exact>
         {intl.formatMessage(i18nMessages.home)}
@@ -166,8 +166,8 @@ const ThreeOneOneMobileMenuItem = injectIntl(({intl}) => (
   </li>
 ))
 
-const PrivacyPolicyMenuItem = injectIntl(({handleToggleAllMenus, intl}) => (
-  <li className="d-lg-none" onClick={handleToggleAllMenus}>
+const PrivacyPolicyMenuItem = injectIntl(({handleCloseAllMenus, intl}) => (
+  <li className="d-lg-none" onClick={handleCloseAllMenus}>
     <div className="coa-MenuItem coa-MenuItem--small">
       <a href="#">
         {intl.formatMessage(i18nMessages.privacy)}
@@ -194,7 +194,7 @@ const MobileFooter = injectIntl(({intl}) => (
 
 Menu.propTypes = {
   navigation: PropTypes.object.isRequired,
-  toggleMenu: PropTypes.func.isRequired,
+  closeMenu: PropTypes.func.isRequired,
   isMenuOpen: PropTypes.bool,
 }
 

--- a/src/js/page_sections/Menu/MenuItem.js
+++ b/src/js/page_sections/Menu/MenuItem.js
@@ -7,7 +7,7 @@ import PlusSVG from 'js/svg/Plus';
 import MinusSVG from 'js/svg/Minus';
 import ChevronDownSVG from 'js/svg/ChevronDown';
 
-const MenuItem = ({theme, id, isSubmenuOpen, handleSubmenuToggle, handleToggleAllMenus}) => (
+const MenuItem = ({theme, id, isSubmenuOpen, handleSubmenuToggle, handleCloseAllMenus}) => (
   <li>
     <div className={`coa-MenuItem coa-MenuItem--flex ${isSubmenuOpen ? 'coa-MenuItem--open' : ''}`}
       id={`theme${id+1}`}
@@ -35,7 +35,7 @@ const MenuItem = ({theme, id, isSubmenuOpen, handleSubmenuToggle, handleToggleAl
       id={id}
       theme={theme}
       isSubmenuOpen={isSubmenuOpen}
-      handleToggleAllMenus={handleToggleAllMenus}
+      handleCloseAllMenus={handleCloseAllMenus}
     />
   )}
   </li>

--- a/src/js/page_sections/Menu/Submenu.js
+++ b/src/js/page_sections/Menu/Submenu.js
@@ -16,7 +16,7 @@ const isAlignedRight = (direction, id) => {
   return (direction === 'rtl') ? id < SUBMENU_THRESHOLD_ALIGNRIGHT_RTL : id > SUBMENU_THRESHOLD_ALIGNRIGHT_LTR;
 };
 
-const Submenu = ({id, theme, isSubmenuOpen, handleToggleAllMenus, intl}) => {
+const Submenu = ({id, theme, isSubmenuOpen, handleCloseAllMenus, intl}) => {
 
   const langObj = find(SUPPORTED_LANGUAGES, {'code': intl.locale});
   return (
@@ -35,21 +35,21 @@ const Submenu = ({id, theme, isSubmenuOpen, handleToggleAllMenus, intl}) => {
             key={topicId}
             className="coa-SubmenuItem__block coa-SubmenuItem__block--link"
             topic={topic}
-            handleToggleAllMenus={handleToggleAllMenus}
+            handleCloseAllMenus={handleCloseAllMenus}
           />
         );
       })
     }
-      <ThemeSubmenuItem theme={theme} handleToggleAllMenus={handleToggleAllMenus}/>
+      <ThemeSubmenuItem theme={theme} handleCloseAllMenus={handleCloseAllMenus}/>
       <WorkInProgressSubmenuItem />
     </ul>
   );
 }
 
-const ThemeSubmenuItem = ({theme, handleToggleAllMenus}) => (
+const ThemeSubmenuItem = ({theme, handleCloseAllMenus}) => (
   <li className="coa-SubmenuItem"
     role="menuitem"
-    onClick={handleToggleAllMenus}
+    onClick={handleCloseAllMenus}
   >
     <I18nNavLink
       to={`/themes/${theme.slug}`}

--- a/src/js/page_sections/Menu/SubmenuItem.js
+++ b/src/js/page_sections/Menu/SubmenuItem.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 
 import I18nNavLink from 'js/modules/I18nNavLink';
 
-const SubmenuItem = ({ className, topic, handleToggleAllMenus }) => (
-  <li onClick={handleToggleAllMenus} className="coa-SubmenuItem" role="menuitem">
+const SubmenuItem = ({ className, topic, handleCloseAllMenus }) => (
+  <li onClick={handleCloseAllMenus} className="coa-SubmenuItem" role="menuitem">
     <I18nNavLink
       to={`/topics/${topic.slug}`}
       className={className}


### PR DESCRIPTION
Related to: https://github.com/cityofaustin/techstack/issues/236
Addressed
- On all page templates- when sizing screen down from desktop to tablet and mobile, the menu appears automatically/is open in the smaller screens.

I'll need some assistance updating storybooks since I'm not 100% on what actions do. So I'll not merge this until we've update storybooks.

Before Bug fix
![menubefore](https://user-images.githubusercontent.com/3039125/38657047-cc19d75a-3de3-11e8-90a4-b3e17cd24a00.gif)

After Bug fix
![menuafter](https://user-images.githubusercontent.com/3039125/38657054-d230fa88-3de3-11e8-9fa9-dcd8feb0cb2a.gif)
