### PR TITLE
Sd designv2 fixes

### DIFF
--- a/src/css/base/_variables.scss
+++ b/src/css/base/_variables.scss
@@ -1,5 +1,5 @@
 //typography
-@import url('https://fonts.googleapis.com/css?family=Lora|Open+Sans:400,600,700,800');
+@import url('https://fonts.googleapis.com/css?family=Lora:400,400i|Open+Sans:400,600,700,800&text=Welcome%20to');
 /* TODO: determine fallback fonts */
 $coa-font-sans: 'Open Sans';
 $coa-font-serif: 'Lora';

--- a/src/css/modules/_Recollect.scss
+++ b/src/css/modules/_Recollect.scss
@@ -12,6 +12,9 @@
       line-height: $coa-line-height-large;
       text-transform: uppercase;
     }
+    #recollect-social {
+      display: none !important;
+    }
     .rChelp.btn-link {
       display:none;
     }

--- a/src/css/modules/_SectionHeader.scss
+++ b/src/css/modules/_SectionHeader.scss
@@ -18,7 +18,7 @@
 
 .coa_SectionHeader--hasHighlight:after {
   margin: $coa-spacing-medium auto $coa-spacing-xlarge;
-  width: 40px;
+  width: 34px;
   background: $coa-color-orange;
   height: 8px;
   display: block;
@@ -26,5 +26,18 @@
 }
 
 .coa_SectionHeader__arrow {
-  margin: 0 $coa-space-level1;
+  margin: 0 $coa-spacing-xsmall;
+  svg {
+    height: 14px;
+    @include media($coa-small-screen) {
+      height: 20px;
+    }
+    @include media($coa-medium-screen) {
+      height: 30px;
+    }
+    @include media($coa-large-screen) {
+      height: 38px;
+    }
+  }
+
 }

--- a/src/css/page_sections/Menu/_SubmenuItem.scss
+++ b/src/css/page_sections/Menu/_SubmenuItem.scss
@@ -48,4 +48,7 @@
 
 .coa-SubmenuItem__arrow-right {
   margin: 0 $coa-spacing-small;
+  svg {
+    height: 13px;
+  }
 }

--- a/src/js/components/LanguageWrapper.js
+++ b/src/js/components/LanguageWrapper.js
@@ -40,12 +40,6 @@ class LanguageWrapper extends Component {
     }
   }
 
-  getChildContext() {
-    return {
-      langCode: this.state.lang
-    };
-  }
-
   getInitialLangState() {
     const getLang = [ this.getLangFromProps, this.getLangFromCookie, this.getLangFromLocale, ()=>DEFAULT_LANG ];
     const that = this;
@@ -139,9 +133,6 @@ class LanguageWrapper extends Component {
 
 LanguageWrapper.propTypes = {
   navigation: PropTypes.object.isRequired,
-}
-LanguageWrapper.childContextTypes = {
-  langCode: PropTypes.string
 }
 
 export default withSiteData(LanguageWrapper);

--- a/src/js/components/LanguageWrapper.js
+++ b/src/js/components/LanguageWrapper.js
@@ -125,7 +125,7 @@ class LanguageWrapper extends Component {
       <IntlProvider locale={lang} messages={messages} defaultLocale={DEFAULT_LANG} key={lang}>
         <div style={{ position: 'relative' }} dir={direction} className={`coa-${direction}`}>
           <a href="#main" className="usa-skipnav">Skip to main content</a>
-          <LanguageSelectBar lang={lang} path={this.props.match.params.path || ''}/>
+          <LanguageSelectBar path={this.props.match.params.path || ''}/>
           <Header navigation={navigation[lang]} />
           <main role="main" id="main">
             <Routes />

--- a/src/js/i18n/constants.js
+++ b/src/js/i18n/constants.js
@@ -59,7 +59,7 @@ export const LANG_COOKIE_EXPIRES = 10 * 365; //days
 
 export const DEFAULT_LANG = 'en';
 
-export const i18nalizeLinkTo = ({to, langCode=DEFAULT_LANG}) => {
+export const i18nalizeLinkTo = (to, langCode=DEFAULT_LANG) => {
   let location;
   if (!to) return null;
   if (typeof to !== "string") location = to.pathname;

--- a/src/js/modules/I18nLink.js
+++ b/src/js/modules/I18nLink.js
@@ -1,16 +1,11 @@
 import React from 'react';
+import { injectIntl } from 'react-intl';
 import { Link } from 'react-static'
 import PropTypes from 'prop-types'
 import { i18nalizeLinkTo } from 'js/i18n/constants'
 
-const I18nLink = (props, context) => {
-  const { to, ...rest } = props;
-  const { langCode } = context;
-  return <Link to={i18nalizeLinkTo({to, langCode})} {...rest} />
-}
+const I18nLink = ({ intl, to, ...rest }) => (
+  <Link to={i18nalizeLinkTo(to, intl.locale)} {...rest} />
+)
 
-I18nLink.contextTypes = {
-  langCode: PropTypes.string,
-}
-
-export default I18nLink;
+export default injectIntl(I18nLink);

--- a/src/js/modules/I18nNavLink.js
+++ b/src/js/modules/I18nNavLink.js
@@ -1,16 +1,11 @@
 import React from 'react'
+import { injectIntl } from 'react-intl';
 import { NavLink } from 'react-static'
 import PropTypes from 'prop-types'
 import { i18nalizeLinkTo } from 'js/i18n/constants'
 
-const I18nNavLink = (props, context) => {
-  const { to, ...rest } = props;
-  const { langCode } = context;
-  return <NavLink to={i18nalizeLinkTo({to, langCode})} {...rest} />
-}
+const I18nNavLink = ({ intl, to, ...rest }) => (
+  <NavLink to={i18nalizeLinkTo(to, intl.locale)} {...rest} />
+)
 
-I18nNavLink.contextTypes = {
-  langCode: PropTypes.string,
-}
-
-export default I18nNavLink;
+export default injectIntl(I18nNavLink);

--- a/src/js/modules/PageBreadcrumbs.js
+++ b/src/js/modules/PageBreadcrumbs.js
@@ -3,6 +3,13 @@ import { defineMessages, injectIntl } from 'react-intl';
 import I18nLink from 'js/modules/I18nLink';
 import PropTypes from 'prop-types';
 
+const i18nMessages = defineMessages({
+  home: {
+    id: 'PageBreadcrumbs.Home.text',
+    defaultMessage: 'Home',
+  }
+});
+
 const Breadcrumb = ({ breadcrumb, classNameSuffix }) => (
   <I18nLink
     className={`coa-PageBreadcrumbs__${classNameSuffix}`}
@@ -15,31 +22,21 @@ const Breadcrumb = ({ breadcrumb, classNameSuffix }) => (
   </I18nLink>
 );
 
-const PageBreadcrumbs = ({ intl, title, grandparent, parent }) => {
-
-  const i18nMessages = defineMessages({
-    home: {
-      id: 'PageBreadcrumbs.Home.text',
-      defaultMessage: 'Home',
-    }
-  });
-
-  const home = ({
-    text: intl.formatMessage(i18nMessages.home),
-    slug: '',
-  });
-
-  return (
-    <div className="wrapper container-fluid">
-      <div className="coa-PageBreadcrumbs">
-        <Breadcrumb breadcrumb={home} classNameSuffix="home" />
-        { grandparent && <Breadcrumb breadcrumb={grandparent} classNameSuffix="grandparent" />}
-        { parent && <Breadcrumb breadcrumb={parent} classNameSuffix="parent" />}
-        <span className="coa-PageBreadcrumbs__title">{title}</span>
-      </div>
+const PageBreadcrumbs = ({ intl, title, grandparent, parent }) => (
+  <div className="wrapper container-fluid">
+    <div className="coa-PageBreadcrumbs">
+      <Breadcrumb breadcrumb={{
+          text: intl.formatMessage(i18nMessages.home),
+          slug: '',
+        }}
+        classNameSuffix="home"
+      />
+      { grandparent && <Breadcrumb breadcrumb={grandparent} classNameSuffix="grandparent" />}
+      { parent && <Breadcrumb breadcrumb={parent} classNameSuffix="parent" />}
+      <span className="coa-PageBreadcrumbs__title">{title}</span>
     </div>
-  );
-}
+  </div>
+);
 
 PageBreadcrumbs.propTypes = {
   title: PropTypes.string,

--- a/src/js/modules/SectionHeader.js
+++ b/src/js/modules/SectionHeader.js
@@ -11,7 +11,7 @@ const SectionHeader = ({ isSerif, hasHighlight, hasArrow, children }) => (
     {children}
     {hasArrow && (
       <span className="coa_SectionHeader__arrow">
-        <ArrowRight size={32}/>
+        <ArrowRight />
       </span>
     )}
   </h2>

--- a/src/js/page_sections/LanguageSelectBar.js
+++ b/src/js/page_sections/LanguageSelectBar.js
@@ -1,8 +1,9 @@
 import React from 'react';
-import { NavLink } from 'react-static';
+import { injectIntl } from 'react-intl';
+import { Link } from 'react-static';
 import { SUPPORTED_LANGUAGES } from 'js/i18n/constants';
 
-const LanguageSelectBar = ({path, lang}) => (
+const LanguageSelectBar = ({path, intl}) => (
   <div className="coa-LanguageSelectBar">
     <div className="container-fluid wrapper">
       <div className="coa-LanguageSelectBar__language-list">
@@ -10,13 +11,13 @@ const LanguageSelectBar = ({path, lang}) => (
           SUPPORTED_LANGUAGES.map(({title, abbr, code}, i) => {
             return (
               <li key={i}>
-                <NavLink
+                <Link
                   to={`/${code}/${path}`}
-                  className="coa-LanguageSelectBar__language-item"
-                  activeClassName="coa-LanguageSelectBar__language-item--active"
+                  className={`coa-LanguageSelectBar__language-item
+                  ${intl.locale === code ? 'coa-LanguageSelectBar__language-item--active' : ''}`}
                 >
                   {title}
-                </NavLink>
+                </Link>
               </li>
             )
           })
@@ -26,4 +27,4 @@ const LanguageSelectBar = ({path, lang}) => (
   </div>
 )
 
-export default LanguageSelectBar;
+export default injectIntl(LanguageSelectBar);

--- a/src/js/page_sections/Menu/Menu.js
+++ b/src/js/page_sections/Menu/Menu.js
@@ -68,7 +68,7 @@ class Menu extends Component {
 
   toggleSubmenu = (e, openSubmenuId) => {
     if (e.type === "keydown" && e.key !== 'Enter') return false;
-    if (openSubmenuId && openSubmenuId === this.state.openSubmenuId) {
+    if (openSubmenuId === this.state.openSubmenuId) {
       this.setState({
         openSubmenuId: null
       })

--- a/src/js/svg/ArrowRight.js
+++ b/src/js/svg/ArrowRight.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const ArrowRight = ({ size }) => (
-  <svg width={size} height={size} viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg">
+  <svg viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg">
     <title id="title">Arrow Right</title>
     <path d="M1600 960q0 54-37 91l-651 651q-39 37-91 37-51 0-90-37l-75-75q-38-38-38-91t38-91l293-293h-704q-52 0-84.5-37.5t-32.5-90.5v-128q0-53 32.5-90.5t84.5-37.5h704l-293-294q-38-36-38-90t38-90l75-75q38-38 90-38 53 0 91 38l651 651q37 35 37 90z"/>
   </svg>

--- a/src/js/svg/ArrowRight.js
+++ b/src/js/svg/ArrowRight.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const ArrowRight = ({ size }) => (
+const ArrowRight = (props) => (
   <svg viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg">
     <title id="title">Arrow Right</title>
     <path d="M1600 960q0 54-37 91l-651 651q-39 37-91 37-51 0-90-37l-75-75q-38-38-38-91t38-91l293-293h-704q-52 0-84.5-37.5t-32.5-90.5v-128q0-53 32.5-90.5t84.5-37.5h704l-293-294q-38-36-38-90t38-90l75-75q38-38 90-38 53 0 91 38l651 651q37 35 37 90z"/>


### PR DESCRIPTION
Related to: https://github.com/cityofaustin/techstack/issues/236

Closes:
-  'Welcome to' in Lora italic does not match mock-up
- After opening menu item 'Permits & Tickets', user is unable to close it. All other menu items will close.
- when breaking from desktop and tablet to mobile, the arrow on the tile group header does not scale down
- 'English' in language bar should be highlighted when someone first arrives to the site showing them the active language
- remove share link from recollect app in all instances
- when breaking from desktop and tablet to mobile, the arrow on the tile group header does not scale down

Also Related to: https://github.com/cityofaustin/techstack/issues/242
Closes 1, 2, 3