### PR TITLE
refactor tile component layout logic. clean data in toplevel components

### DIFF
--- a/src/css/base/_variables.scss
+++ b/src/css/base/_variables.scss
@@ -53,7 +53,7 @@ $coa-spacing-xlarge: $coa-space-level8;
 
 //flexbox grid
 $coa-column-count: 12;
-$coa-gutter-width: 2.5rem;
+$coa-gutter-width: 2rem;
 $coa-container-margin: 2rem;
 $coa-wrapper-maxwidth: 1325px;
 $coa-wrapper-sm-maxwidth: 720px;
@@ -89,6 +89,5 @@ $coa-languageselectbar-height: 50px;
 $coa-button-border-radius: 4px;
 $coa-tile-height: 242px;
 $coa-tile-min-width: 200px;
-$coa-tile-spacearound: 1%;
 $coa-tile-group-border-radius: 6px;
 $coa-tile-group-border: 4px;

--- a/src/css/modules/_SectionHeader.scss
+++ b/src/css/modules/_SectionHeader.scss
@@ -1,6 +1,24 @@
 .coa_SectionHeader {
   text-transform: uppercase;
   text-align: center;
+
+  a {
+    color: $coa-color-purple-darkest;
+    text-decoration: none;
+  }
+
+  svg {
+    height: 14px;
+    @include media($coa-small-screen) {
+      height: 20px;
+    }
+    @include media($coa-medium-screen) {
+      height: 30px;
+    }
+    @include media($coa-large-screen) {
+      height: 38px;
+    }
+  }
 }
 
 .coa_SectionHeader--isSerif {
@@ -23,21 +41,4 @@
   height: 8px;
   display: block;
   content: "";
-}
-
-.coa_SectionHeader__arrow {
-  margin: 0 $coa-spacing-xsmall;
-  svg {
-    height: 14px;
-    @include media($coa-small-screen) {
-      height: 20px;
-    }
-    @include media($coa-medium-screen) {
-      height: 30px;
-    }
-    @include media($coa-large-screen) {
-      height: 38px;
-    }
-  }
-
 }

--- a/src/css/modules/_Tile.scss
+++ b/src/css/modules/_Tile.scss
@@ -3,7 +3,6 @@
   display: flex;
   flex-direction: column;
   height: $coa-tile-height;
-  margin: $coa-spacing-small;
   min-width: $coa-tile-min-width;
   padding: $coa-spacing-medium $coa-spacing-medium $coa-spacing-large ;
   text-decoration: none;

--- a/src/css/modules/_TileGroup.scss
+++ b/src/css/modules/_TileGroup.scss
@@ -1,15 +1,12 @@
 .coa-TileGroup {
+
+  .coa-TileGroup__description {
+    text-align: center;
+  }
+
   .coa-Tile {
-    flex-grow: 1 ;
-    flex-shrink: 0;
-    flex-basis: 98%;
-    margin: $coa-tile-spacearound;
-    @include media($coa-small-screen) {
-      flex-basis: 50% - (4 * $coa-tile-spacearound);
-    }
-    @include media($coa-large-screen) {
-      flex-basis: 25% - (8 * $coa-tile-spacearound);
-    }
+    margin-bottom: $coa-gutter-width / 2;
+    margin-top: $coa-gutter-width / 2;
   }
 }
 
@@ -18,22 +15,4 @@
   border-radius: $coa-tile-group-border-radius;
   padding: 0 $coa-space-level4 $coa-space-level4;
   margin: $coa-space-level7 $coa-space-level6;
-}
-
-.coa-TileGroup__title {
-  margin: auto;
-  a {
-    text-decoration: none;
-    color: $coa-color-purple-darkest;
-  }
-}
-
-.coa-TileGroup__tiles {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-}
-
-.coa-TileGroup__tiles--column {
-  flex-direction: column;
 }

--- a/src/css/modules/_TileGroupSet.scss
+++ b/src/css/modules/_TileGroupSet.scss
@@ -1,4 +1,45 @@
 .coa-TileGroupSet {
   display: flex;
   justify-content: center;
+
+  .coa-TileGroup {
+    margin: 1%;
+    width: 100% - 1% * 2;
+  }
+
+  @include media($coa-medium-screen) {
+
+    /* two or more groups */
+    .coa-TileGroup:nth-last-child(n+2):first-child,
+    .coa-TileGroup:nth-last-child(n+2):first-child  ~ .coa-TileGroup {
+      width: 50% - 1% * 2;
+      .coa-TileGroup__tile {
+        flex-basis: 100%;
+        max-width: 100%;
+      }
+    }
+  }
+
+  @include media($coa-large-screen) {
+
+    /* two groups */
+    .coa-TileGroup:nth-last-child(2):first-child,
+    .coa-TileGroup:nth-last-child(2):first-child  ~ .coa-TileGroup {
+      width: 50% - 1% * 2;
+      .coa-TileGroup__tile {
+        flex-basis: 50%;
+        max-width: 50%;
+      }
+    }
+
+    /* three or more groups */
+    .coa-TileGroup:nth-last-child(n+3):first-child,
+    .coa-TileGroup:nth-last-child(n+3):first-child ~ .coa-TileGroup {
+      width: 33% - 1% * 2;
+      .coa-TileGroup__tile {
+        flex-basis: 100%;
+        max-width: 100%;
+      }
+    }
+  }
 }

--- a/src/js/helpers/cleanData.js
+++ b/src/js/helpers/cleanData.js
@@ -55,14 +55,16 @@ export const cleanRelatedServiceLinks = (links) => {
   });
 };
 
-export const cleanServiceLinks = (links) => {
+export const cleanLinks = (links, pathPrefix) => {
 
   if(!links || !links.edges) return null;
 
   return links.edges.map(({node: link}) => {
+    const {title, slug, ...rest} = link;
     return {
-      url: `/services/${link.slug}`,
-      text: link.title
+      url: `${pathPrefix || ''}/${slug}`,
+      text: title,
+      ...rest
     }
   });
 };

--- a/src/js/modules/SectionHeader.js
+++ b/src/js/modules/SectionHeader.js
@@ -1,26 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ArrowRight from 'js/svg/ArrowRight';
 
-
-const SectionHeader = ({ isSerif, hasHighlight, hasArrow, children }) => (
+const SectionHeader = ({ isSerif, hasHighlight, children }) => (
   <h2 className={`coa_SectionHeader
     ${hasHighlight ? 'coa_SectionHeader--hasHighlight' : ''}
     ${isSerif ? 'coa_SectionHeader--isSerif' : ''} `
   }>
     {children}
-    {hasArrow && (
-      <span className="coa_SectionHeader__arrow">
-        <ArrowRight />
-      </span>
-    )}
   </h2>
 );
 
 SectionHeader.propTypes = {
   isSerif: PropTypes.bool,
   hasHighlight: PropTypes.bool,
-  hasArrow: PropTypes.bool,
 };
 
 export default SectionHeader;

--- a/src/js/modules/Tile.js
+++ b/src/js/modules/Tile.js
@@ -14,6 +14,7 @@ const Tile = ({ url, text, tag }) => (
 Tile.propTypes = {
   url: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
+  tag: PropTypes.string,
 };
 
 export default Tile;

--- a/src/js/modules/TileGroup.js
+++ b/src/js/modules/TileGroup.js
@@ -4,35 +4,37 @@ import PropTypes from 'prop-types';
 import Tile from 'js/modules/Tile';
 import SectionHeader from 'js/modules/SectionHeader';
 import I18nLink from 'js/modules/I18nLink';
+import ArrowRight from 'js/svg/ArrowRight';
 
 
-const TileGroup = ({ tiles, tag, hasBorder, title, description, titlePath, direction }) => (
-  <div className={`
-    col-xs-12 ${direction ? 'col-md-6 col-lg-3' : ''}
-    coa-TileGroup ${hasBorder ? 'coa-TileGroup--border' : ''}
-  `}>
-  { title && (
-    <div className="coa-TileGroup__title">
+const TileGroup = ({ tiles, tag, title, titlePath, description, hasBorder }) => (
+  <div className={`coa-TileGroup ${hasBorder ? 'coa-TileGroup--border' : ''}`}>
+  { title && titlePath && (
+    <SectionHeader hasHighlight={true}>
       <I18nLink to={titlePath}>
-        <SectionHeader hasHighlight={true} hasArrow={true}>{title}</SectionHeader>
+        {title}&nbsp;<ArrowRight />
       </I18nLink>
-    </div>
+    </SectionHeader>
   )}
-  { description && <p>{description}</p> }
-    <div className={`
-      coa-TileGroup__tiles
-      ${direction ? `coa-TileGroup__tiles--${direction}` : ''}
-    `}>
+  { title && !titlePath && (
+    <SectionHeader hasHighlight={true}>{title}</SectionHeader>
+  )}
+
+  { description && (
+    <p className="coa-TileGroup__description">{description}</p>
+  )}
+    <div className="row">
       {
         tiles.map(({ url, text }, index) =>
-        <Tile
-          url={url}
-          text={text}
-          tag={tag}
-          key={index}
-        />
-      )
-    }
+          <div key={index} className="coa-TileGroup__tile col-xs-12 col-md-6 col-lg-3">
+            <Tile
+              url={url}
+              text={text}
+              tag={tag}
+            />
+          </div>
+        )
+      }
     </div>
   </div>
 )
@@ -40,10 +42,10 @@ const TileGroup = ({ tiles, tag, hasBorder, title, description, titlePath, direc
 TileGroup.propTypes = {
   tiles: PropTypes.array.isRequired,
   tag: PropTypes.string,
-  hasBorder: PropTypes.bool,
   title: PropTypes.string,
-  description: PropTypes.string,
   titlePath: PropTypes.string,
+  description: PropTypes.string,
+  hasBorder: PropTypes.bool,
 };
 
 export default TileGroup;

--- a/src/js/modules/TileGroupSet.js
+++ b/src/js/modules/TileGroupSet.js
@@ -3,47 +3,34 @@ import PropTypes from 'prop-types';
 
 import TileGroup from 'js/modules/TileGroup';
 
-
-const TileGroupSet = ({ groups, tileKey, groupTitleSubPath }) =>  {
-
-  // gets the number of topics that have active services
-  const countOfGroups = groups.edges
-    .map((g) => g.node.services.edges.length > 0)
-    .reduce((total, amount) => amount ? total + 1 : total, 0);
-  const shouldTilesStackVertical = countOfGroups > 1;
-
+const TileGroupSet = ({ tileGroups, tag }) =>  {
   return (
-    <div className="coa-TileGroupSet row">
-    {
-      groups && groups.edges.map(({node: group}, index) => {
-        if (group.services.edges.length < 1) return false;
-
-        const tiles = group[tileKey].edges.map((tile) => ({
-          url: `/${tileKey}/${tile.node.slug}`,
-          text: tile.node.title,
-        }));
-
-        return (
-          <TileGroup tiles={tiles}
-            tag="service"
-            hasBorder={true}
-            title={group.text}
-            key={index}
-            titlePath={`/${groupTitleSubPath}/${group.slug}`}
-            description={group.description}
-            direction={shouldTilesStackVertical ? 'column' : false}
-          />
-        )
-      })
-    }
+    <div className="coa-TileGroupSet">
+      <div className="row">
+      {
+        tileGroups.map(({ tiles, text, url, description }, index) => {
+          if (!tiles.length) return null;
+          return (
+            <TileGroup
+              key={index}
+              tiles={tiles}
+              tag={tag}
+              title={text}
+              titlePath={url}
+              description={description}
+              hasBorder={true}
+            />
+          );
+        })
+      }
+      </div>
     </div>
   );
 }
 
 TileGroupSet.propTypes = {
-  groups: PropTypes.object.isRequired,
-  tileKey: PropTypes.string,
-  groupTitleSubPath: PropTypes.string,
+  tileGroups: PropTypes.array.isRequired,
+  tag: PropTypes.string,
 };
 
 export default TileGroupSet;

--- a/src/js/pages/Home.js
+++ b/src/js/pages/Home.js
@@ -9,7 +9,7 @@ import HeroHome from 'js/modules/HeroHome';
 import ExternalLink from 'js/modules/ExternalLink';
 import SectionHeader from 'js/modules/SectionHeader';
 import TileGroup from 'js/modules/TileGroup';
-import { cleanServiceLinks } from 'js/helpers/cleanData';
+import { cleanLinks } from 'js/helpers/cleanData';
 
 import jsonFileData from '__tmpdata/pages';
 const services311 = get(jsonFileData, "services311", null);
@@ -30,7 +30,8 @@ const i18nMessages = defineMessages({
 });
 
 const Home = ({ topServices, image, intl }) => {
-  const serviceLinks = cleanServiceLinks(topServices);
+  //TODO: clean data where sourced
+  const serviceLinks = cleanLinks(topServices, '/services');
 
   return (
     <div>
@@ -52,8 +53,11 @@ const Home = ({ topServices, image, intl }) => {
         </p>
       </SecondaryContentBanner>
       <div className="wrapper container-fluid">
-        <SectionHeader hasHighlight={true}>{intl.formatMessage(i18nMessages.homeRelatedlinksSectiontitle)}</SectionHeader>
-        <TileGroup tiles={serviceLinks} tag={intl.formatMessage(i18nMessages.homeRelatedlinksTag)} />
+        <TileGroup
+          title={intl.formatMessage(i18nMessages.homeRelatedlinksSectiontitle)}
+          tiles={serviceLinks}
+          tag={intl.formatMessage(i18nMessages.homeRelatedlinksTag)}
+        />
       </div>
       <ThreeOneOne services311={services311} />
     </div>

--- a/src/js/pages/Service.js
+++ b/src/js/pages/Service.js
@@ -86,8 +86,11 @@ const Service = ({ service, intl }) => {
       </div>
 
       <div className="wrapper container-fluid">
-        <SectionHeader hasHighlight={true}>{intl.formatMessage(i18nMessages.serviceRelatedlinksSectionheader)}</SectionHeader>
-        <TileGroup tiles={cleanedRelated} tag={intl.formatMessage(i18nMessages.serviceRelatedlinksTag)} />
+        <TileGroup
+          title={intl.formatMessage(i18nMessages.serviceRelatedlinksSectionheader)}
+          tiles={cleanedRelated}
+          tag={intl.formatMessage(i18nMessages.serviceRelatedlinksTag)}
+        />
       </div>
 
       <div className="wrapper wrapper--sm container-fluid">

--- a/src/js/pages/Services.js
+++ b/src/js/pages/Services.js
@@ -7,7 +7,7 @@ import PageHeader from 'js/modules/PageHeader';
 import TileGroup from 'js/modules/TileGroup';
 import ThreeOneOne from 'js/page_sections/ThreeOneOne';
 
-import { cleanServiceLinks } from 'js/helpers/cleanData';
+import { cleanLinks } from 'js/helpers/cleanData';
 
 // TODO: this jsonFileData is temporary. Add it to Wagtail API
 import jsonFileData from '__tmpdata/pages';
@@ -25,7 +25,8 @@ const i18nMessages = defineMessages({
 })
 
 const Services = ({ allServices, intl }) => {
-  const relatedLinks = cleanServiceLinks(allServices)
+  //TODO: clean data where sourced
+  const relatedLinks = cleanLinks(allServices, '/services');
 
   return (
     <div>
@@ -36,7 +37,7 @@ const Services = ({ allServices, intl }) => {
         />
       </div>
       <div className="wrapper container-fluid">
-        <TileGroup tiles={relatedLinks} />
+        <TileGroup tiles={relatedLinks} tag="service" />
       </div>
       <ThreeOneOne services311={services311} />
     </div>

--- a/src/js/pages/Theme.js
+++ b/src/js/pages/Theme.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { withRouteData } from 'react-static';
 import PropTypes from 'prop-types';
+import { cleanLinks } from 'js/helpers/cleanData';
 
 // TODO: this jsonFileData is temporary. Add it to Wagtail API
 import jsonFileData from '__tmpdata/pages';
@@ -10,6 +11,12 @@ import ThreeOneOne from 'js/page_sections/ThreeOneOne';
 
 const Theme = ({ theme }) => {
   const { text: title, callToAction, description, topics } = theme;
+  //TODO: clean data where sourced
+  let cleanedTopics = cleanLinks(topics, '/topics');
+  cleanedTopics.map(topic => {
+    topic.tiles = cleanLinks(topic.services, '/services');
+  });
+
   const { services311 } = jsonFileData;
 
   return (
@@ -19,11 +26,7 @@ const Theme = ({ theme }) => {
       </div>
 
       <div className="wrapper container-fluid">
-        <TileGroupSet
-          groups={topics}
-          tileKey={'services'}
-          groupTitleSubPath={'topics'}
-        />
+        <TileGroupSet tileGroups={cleanedTopics} tag="service" />
       </div>
 
       <ThreeOneOne services311={services311} />

--- a/src/js/pages/Themes.js
+++ b/src/js/pages/Themes.js
@@ -6,15 +6,14 @@ import PageHeader from 'js/modules/PageHeader';
 import TileGroup from 'js/modules/TileGroup';
 import ThreeOneOne from 'js/page_sections/ThreeOneOne';
 
+import { cleanLinks } from 'js/helpers/cleanData';
+
 // TODO: this jsonFileData is temporary. Add it to Wagtail API
 import jsonFileData from '__tmpdata/pages';
 const services311 = get(jsonFileData, "services311", null);
 
 const Themes = ({ allThemes }) => {
-  const links = allThemes.edges.map(theme => ({
-    url: `/themes/${theme.node.slug}`,
-    text: theme.node.text,
-  }));
+  const links = cleanLinks(allThemes, '/themes');
 
   return (
     <div>

--- a/src/js/pages/Topic.js
+++ b/src/js/pages/Topic.js
@@ -10,7 +10,7 @@ import PageBreadcrumbs from 'js/modules/PageBreadcrumbs';
 import PageHeader from 'js/modules/PageHeader';
 import SectionHeader from 'js/modules/SectionHeader';
 import ThreeOneOne from 'js/page_sections/ThreeOneOne';
-import { cleanServiceLinks } from 'js/helpers/cleanData';
+import { cleanLinks } from 'js/helpers/cleanData';
 
 const i18nMessages = defineMessages({
   serviceRelatedlinksTag: {
@@ -29,7 +29,8 @@ const Topic = ({ topic, intl }) => {
   } = topic;
 
   const { services311 } = jsonFileData;
-  const relatedLinks = cleanServiceLinks(links);
+  //TODO: clean data where sourced
+  const relatedLinks = cleanLinks(links, '/services');
 
   return (
     <div>

--- a/src/js/pages/Topics.js
+++ b/src/js/pages/Topics.js
@@ -6,15 +6,14 @@ import PageHeader from 'js/modules/PageHeader';
 import TileGroup from 'js/modules/TileGroup';
 import ThreeOneOne from 'js/page_sections/ThreeOneOne';
 
+import { cleanLinks } from 'js/helpers/cleanData';
+
 // TODO: this jsonFileData is temporary. Add it to Wagtail API
 import jsonFileData from '__tmpdata/pages';
 const services311 = get(jsonFileData, "services311", null);
 
 const Topics = ({ allTopics }) => {
-  const links = allTopics.edges.map(topic => ({
-    url: `/topics/${topic.node.slug}`,
-    text: topic.node.text,
-  }));
+  const links = cleanLinks(allTopics, '/topics');
 
   return (
     <div>


### PR DESCRIPTION
- I refactored the TileGroupSet components to lean more on sibling counts via CSS selectors and viewport widths so our layout decisions could live outside of our JS and in our CSS. 
- I also removed the data cleaning logic out of the TileGroup component so the component does not need to be aware of graphQL nodes and edges. (addresses some of https://github.com/cityofaustin/techstack/issues/244)
- This also handles "body inside tile group should be centered" from https://github.com/cityofaustin/techstack/issues/236 

* Note this PR merges in to another branch with an open PR. I separated the two, since this refactor got heavy.