### PR TITLE
Feedback Form Url and User Agent Logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-static": "^5.6.8",
     "react-universal-component": "^2.8.1",
     "storybook": "^1.0.0",
+    "ua-parser-js": "^0.7.17",
     "uswds": "^1.4.5"
   },
   "devDependencies": {

--- a/src/components/FormFeedback/index.js
+++ b/src/components/FormFeedback/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
+import parser from 'ua-parser-js';
 import { postFeedback } from 'js/helpers/fetchData';
 import { logFormEvent } from 'js/helpers/googleAnalytics';
 import { emojis, i18nEmojis } from 'js/helpers/emojis';
@@ -106,7 +107,9 @@ class FormFeedback extends Component {
     postFeedback({
       title: `Alpha Site Feedback ${emoji}`,
       description: `**Emoji rating (scale of -2 to 2):**\n${emojiValue}: ${emojiText}\n
-        \n**Text feedback:**\n${this.state.feedback}\n\n`,
+        \n**Text feedback:**\n${this.state.feedback}\n
+        \n**Url:**\n${window.location.href}\n
+        \n**Device Information:** \n\`\`\`\n${JSON.stringify(parser(), null, 2)}\n\`\`\`\n\n`,
     })
     .then(({data}) => {
       this.setState({

--- a/src/js/helpers/fetchData.js
+++ b/src/js/helpers/fetchData.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 export const postFeedback = (data) => {
 
-  const { title, description, email } = data;
+  const { title, description } = data;
 
   return axios
     .create({

--- a/yarn.lock
+++ b/yarn.lock
@@ -8352,9 +8352,9 @@ react-split-pane@^0.1.74:
     prop-types "^15.5.10"
     react-style-proptype "^3.0.0"
 
-react-static@^5.7.1:
-  version "5.8.1"
-  resolved "https://registry.yarnpkg.com/react-static/-/react-static-5.8.1.tgz#6f665029980d385263a067b2d17008178356e7f5"
+react-static@^5.6.8:
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/react-static/-/react-static-5.8.2.tgz#c1202ddc31e08ea6819b5ba643cf2a4c1a3203d0"
   dependencies:
     "@types/react" "^16.0.18"
     "@types/react-helmet" "^5.0.3"
@@ -10143,7 +10143,7 @@ typescript@^2.4.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
 
-ua-parser-js@^0.7.9:
+ua-parser-js@^0.7.17, ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
 


### PR DESCRIPTION
closes https://github.com/cityofaustin/techstack/issues/182

feedback form logs user's current url and device info as shown here:
https://github.com/cityofaustin/alpha-feedback/issues/18