### PR TITLE
upgrade react static

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-load-script": "^0.0.6",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
-    "react-static": "^5.6.8",
+    "react-static": "^5.8.5",
     "react-universal-component": "^2.8.1",
     "storybook": "^1.0.0",
     "ua-parser-js": "^0.7.17",


### PR DESCRIPTION
Homepage load [issue](https://github.com/cityofaustin/techstack/issues/289) fixed in latest react static -- so let's upgrade. Initially, we downgraded to fix the issue introduced in react-static ~5.7
https://github.com/nozzle/react-static/issues/567