### PR TITLE
don’t show PageBanner without image prop

### DIFF
--- a/src/components/Pages/Service.js
+++ b/src/components/Pages/Service.js
@@ -31,15 +31,17 @@ const Service = ({
   intl,
 }) => (
   <div>
-    <PageBanner
-      imagesPath={`${process.env.CMS_MEDIA}/images`}
-      imageFilename={path.basename(
-        image.filename,
-        path.extname(image.filename),
-      )}
-      imageExtension={path.extname(image.filename)}
-      imageTitle={image.title}
-    />
+    {image && (
+      <PageBanner
+        imagesPath={`${process.env.CMS_MEDIA}/images`}
+        imageFilename={path.basename(
+          image.filename,
+          path.extname(image.filename),
+        )}
+        imageExtension={path.extname(image.filename)}
+        imageTitle={image.title}
+      />
+    )}
     <PageBreadcrumbs
       grandparent={{ ...theme, subpath: 'themes' }}
       parent={{ ...topic, subpath: 'topics' }}


### PR DESCRIPTION
Closes https://github.com/cityofaustin/techstack/issues/574

@briaguya, when I showed you this at first, I was editing the PageBanner component to have the fallback of using a purplish background div when there is no image. But then I saw that our process pages had already solved this by just not rendering the PageBanner without an image prop so I applied that pattern to the Service page component too.

_service page with preview url rendering with no image in screenshot_
![screen shot 2018-08-02 at 4 11 27 pm](https://user-images.githubusercontent.com/5697474/43611449-be9911ac-966e-11e8-90f6-d5e6786b8be9.png)
