### PR TITLE
get the title into banner images

### DIFF
--- a/src/components/PageBanner/_PageBanner.scss
+++ b/src/components/PageBanner/_PageBanner.scss
@@ -1,13 +1,33 @@
-.coa-PageBanner {
+.coa-PageBannerImage {
   object-fit: cover;
   width: 100%;
   height: 17rem;
   margin-bottom: $coa-space-level4;
-
-  @include media($coa-small-screen) {
-    height: 41rem;
-  }
+  display: none;
   @include media($coa-medium-screen) {
     height: 32rem;
+    display: inherit;
+  }
+}
+
+.coa-PageBannerCover {
+  flex-direction: column;
+  padding: $coa-space-level7 0;
+  height: 15rem;
+  color: $coa-color-white;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: $coa-color-primary;
+  @include media($coa-medium-screen) {
+    height: $coa-herohome-height--medium;
+    background: rgba(0,0,0,.6);
+  }
+  @include media($coa-large-screen) {
+    height: $coa-herohome-height--large;
+  }
+  .usa-search {
+    margin-top: $coa-space-level6;
   }
 }

--- a/src/components/PageBanner/index.js
+++ b/src/components/PageBanner/index.js
@@ -3,14 +3,25 @@ import PropTypes from 'prop-types';
 import ResponsiveImage from 'components/ResponsiveImage';
 import { FULL_WIDTH_RESPONSIVE_IMAGE_SIZES } from 'js/helpers/constants';
 
-const PageBanner = ({ imagesPath, imageFilename, imageExtension, imageTitle }) => (
-  <ResponsiveImage
-    className="coa-PageBanner"
-    filename={`${imagesPath}/${imageFilename}`}
-    widths={FULL_WIDTH_RESPONSIVE_IMAGE_SIZES}
-    extension={imageExtension}
-    aria-label={imageTitle}
-  />
+const PageBanner = ({ imagesPath, imageFilename, imageExtension, imageTitle, headerText }) => (
+  <div className="coa-HeroHome__container">
+    <ResponsiveImage
+      className="coa-PageBannerImage"
+      filename={`${imagesPath}/${imageFilename}`}
+      widths={FULL_WIDTH_RESPONSIVE_IMAGE_SIZES}
+      extension={imageExtension}
+      aria-label={imageTitle}
+    />
+    <div
+      className="coa-PageBannerCover"
+      role="img"
+      aria-label={imageTitle}
+    >
+      <div className="container-fluid wrapper">
+        <h1>{headerText}</h1>
+      </div>
+    </div>
+  </div>
 );
 
 PageBanner.propTypes = {

--- a/src/components/Pages/Department.js
+++ b/src/components/Pages/Department.js
@@ -37,12 +37,9 @@ const Department = ({
           )}
           imageExtension={path.extname(image.filename)}
           imageTitle={image.title}
+          headerText={title}
         />
       )}
-      <PageBreadcrumbs title={title} />
-      <div className="wrapper wrapper--sm container-fluid">
-        <PageHeader>{title}</PageHeader>
-      </div>
       <div className="wrapper wrapper--sm container-fluid">
         <p>Mission: {mission}</p>
         <p>What we do: {whatWeDo}</p>


### PR DESCRIPTION
Go from:
<img width="937" alt="screen shot 2019-02-21 at 1 02 44 pm" src="https://user-images.githubusercontent.com/6384156/53194518-27000980-35d9-11e9-9fd9-6d1c38763862.png">
and
<img width="346" alt="screen shot 2019-02-21 at 1 03 08 pm" src="https://user-images.githubusercontent.com/6384156/53194524-29fafa00-35d9-11e9-9222-34e8a8ff5247.png">
 to:
<img width="942" alt="screen shot 2019-02-21 at 1 03 47 pm" src="https://user-images.githubusercontent.com/6384156/53194530-2f584480-35d9-11e9-801b-6fd49d329786.png">
and
<img width="368" alt="screen shot 2019-02-21 at 1 03 35 pm" src="https://user-images.githubusercontent.com/6384156/53194533-32ebcb80-35d9-11e9-80f7-aa38f685e599.png">
