### PR TITLE
1535 mobile footer

### DIFF
--- a/src/components/PageSections/Footer/_Footer.scss
+++ b/src/components/PageSections/Footer/_Footer.scss
@@ -31,13 +31,17 @@
 
 .coa-Footer__work-in-progress {
   text-align: center;
-  font-size: $coa-font-size-medium;
-  line-height: $coa-line-height-medium;
+  font-size: $coa-font-size-small;
+  line-height: $coa-line-height-small;
+  font-weight: $coa-font-bold;
   white-space: pre-line;
-  // @include media($coa-medium-screen) {
-  //   font-size: $coa-font-size-xxlarge;
-  //   line-height: $coa-line-height-xxlarge;
-  // }
+
+  @include media($coa-medium-screen) {
+    font-size: $coa-font-size-medium;
+    line-height: $coa-line-height-medium;
+    font-weight: $coa-font-regular;
+  }
+
   max-width: 660px;
   margin: auto;
 
@@ -86,11 +90,17 @@
 
 .coa-Footer__more_text_box {
   justify-content: center;
-  font-size: $coa-font-size-smedium;
-  line-height: $coa-line-height-smedium;
   text-align: center;
   max-width: 40rem;
   margin: 3rem;
+
+  font-size: $coa-font-size-xsmall;
+  line-height: $coa-line-height-xsmall;
+
+  @include media($coa-medium-screen) {
+    font-size: $coa-font-size-smedium;
+    line-height: $coa-line-height-smedium;
+  }
 
   a {
     color: $coa-color-white;

--- a/src/components/PageSections/Footer/index.js
+++ b/src/components/PageSections/Footer/index.js
@@ -20,8 +20,8 @@ import { threeoneonePropTypes } from 'components/PageSections/ThreeOneOne/propty
 import FooterSiteMap from 'components/PageSections/Footer/FooterSiteMap';
 
 const Footer = ({ threeoneone, intl }) => (
-  <footer className="coa-FooterContainer">
-    <div className="container-fluid wrapper">
+  <footer> {/* className="coa-FooterContainer" */}
+    {/* <div className="container-fluid wrapper"> */}
       {/*
         Commenting out until we finalize IA and FooterSiteMap menu data + sections
       <FooterSiteMap />
@@ -47,7 +47,7 @@ const Footer = ({ threeoneone, intl }) => (
           </div>
         </div>
       </div>
-    </div>
+    {/* </div> */}
   </footer>
 );
 


### PR DESCRIPTION
Resolves: https://github.com/cityofaustin/techstack/issues/1535
This will probably need to be re-addressed when we add the footer nav in

**From:**
<img width="1620" alt="Screen Shot 2019-03-20 at 4 03 49 AM" src="https://user-images.githubusercontent.com/6384156/54672185-8d3b5780-4ac5-11e9-8599-573d1833d41b.png">
<img width="413" alt="Screen Shot 2019-03-20 at 4 05 10 AM" src="https://user-images.githubusercontent.com/6384156/54672202-93313880-4ac5-11e9-987e-2bdbc6bdbc2d.png">

.
.
.
.
.
.
.
.
.
.
.
.

**To:**
<img width="1623" alt="Screen Shot 2019-03-20 at 4 04 13 AM" src="https://user-images.githubusercontent.com/6384156/54672228-a217eb00-4ac5-11e9-9e11-63f8bd04be82.png">
<img width="347" alt="Screen Shot 2019-03-20 at 4 05 29 AM" src="https://user-images.githubusercontent.com/6384156/54672239-a93ef900-4ac5-11e9-8a66-ee0229cf7563.png">
