### PR TITLE
Issue 1461:  fix contact hours responsive layout issues

### DIFF
--- a/src/components/Contact/Email.js
+++ b/src/components/Contact/Email.js
@@ -6,7 +6,9 @@ import { emailPropTypes } from './proptypes';
 const Email = ({ email }) => (
   <div className="coa-ContactItem coa-ContactEmail">
     <i className="material-icons">mail_outline</i>
-    <a href={`mailto:${email}`}>{email}</a>
+    <div className="coa-ContactItem_content">
+      <a href={`mailto:${email}`}>{email}</a>
+    </div>
   </div>
 );
 

--- a/src/components/Contact/Facebook.js
+++ b/src/components/Contact/Facebook.js
@@ -7,9 +7,11 @@ const Facebook = () => (
     <div className="coa-ContactItem__svg">
       <FacebookAltSVG viewBox={'0 0 1024 1024'} />
     </div>
-    <ExternalLink to="https://www.facebook.com/atxpoliceoversight/">
-      fb.com/atxpoliceoversight/
-    </ExternalLink>
+    <div className="coa-ContactItem_content">
+      <ExternalLink to="https://www.facebook.com/atxpoliceoversight/">
+        fb.com/atxpoliceoversight/
+      </ExternalLink>
+    </div>
   </div>
 );
 

--- a/src/components/Contact/Hours.js
+++ b/src/components/Contact/Hours.js
@@ -25,7 +25,14 @@ class Hours extends Component {
   }
 
   formatTime(time) {
-    return moment(time).format("h:mm A");
+    let style;
+    // Only include minutes in display if there are minutes
+    if (moment(time).minutes()) {
+      style = "h:mma";
+    } else {
+      style = "ha";
+    }
+    return moment(time).format(style);
   }
 
   render() {
@@ -56,7 +63,7 @@ class Hours extends Component {
 
                   {hourIndex > -1 && (
                     <td>
-                      {`${this.formatTime(hours[hourIndex].startTime)} - ${this.formatTime(hours[hourIndex].endTime)}`}
+                      {`${this.formatTime(hours[hourIndex].startTime)}-${this.formatTime(hours[hourIndex].endTime)}`}
                     </td>
                   )}
                   {hourIndex === -1 && (

--- a/src/components/Contact/Twitter.js
+++ b/src/components/Contact/Twitter.js
@@ -7,7 +7,9 @@ const Twitter = () => (
     <div className="coa-ContactItem__svg">
       <TwitterSVG />
     </div>
-    <ExternalLink to="https://twitter.com/atx_opo">@ATX_OPO</ExternalLink>
+    <div className="coa-ContactItem_content">
+      <ExternalLink to="https://twitter.com/atx_opo">@ATX_OPO</ExternalLink>
+    </div>
   </div>
 );
 

--- a/src/components/Contact/_Contact.scss
+++ b/src/components/Contact/_Contact.scss
@@ -1,9 +1,17 @@
+.coa-DepartmentPage__contacts-desktop {
+  width: 315px;
+}
+
 .coa-ContactDetails {
   border-left: none;
   border-right: none;
   padding-bottom: $coa-spacing-large;
 }
 
+/*
+Assumes that there are 2 children for each .coa-ContactItem.
+This will enable proper line wrapping for the :last-child.
+*/
 .coa-ContactItem {
   // border-bottom: 1px dashed $coa-color-purple-dark;
   display: flex;
@@ -30,7 +38,7 @@
   }
 
   & > :last-child {
-    flex: 1 0 auto;
+    flex: 1; /* allows line wrap for long contact values. */
     & > span {
       display: block;
     }
@@ -110,4 +118,12 @@
       text-align: left;
     }
   }
+}
+
+.coa-ContactItem_content {
+  /* Flexbox hack to allow long content to wrap to next line */
+  min-width: 1%;
+  /* Yes, you need both. "word-break" fixes mobile styling */
+  word-wrap: break-word;
+  word-break: break-word;
 }

--- a/src/components/Contact/_Contact.scss
+++ b/src/components/Contact/_Contact.scss
@@ -95,6 +95,9 @@
     font-size: $coa-font-size-xsmall;
     padding-right: 0 !important;
     text-transform: capitalize;
+    /* ".usa-table-borderless th:first-child" uses 6rem, which is too much */
+    padding-right: 1rem !important;
+    font-weight: bold;
   }
   td:last-of-type {
     font-size: $coa-font-size-xsmall;

--- a/src/components/Pages/_Department.scss
+++ b/src/components/Pages/_Department.scss
@@ -133,8 +133,8 @@
   @include media($coa-medium-screen) {
     display: inherit;
   }
-  // padding-right: 10%;
   padding-left: 2rem;
+  min-width: 325px; /* 305px + 20px left padding added by us-design-system */
 }
 
 .coa-DepartmentPage__contacts-mobile {

--- a/src/components/Pages/_Department.scss
+++ b/src/components/Pages/_Department.scss
@@ -134,7 +134,7 @@
     display: inherit;
   }
   padding-left: 2rem;
-  min-width: 325px; /* 305px + 20px left padding added by us-design-system */
+  padding-right: 2rem;
 }
 
 .coa-DepartmentPage__contacts-mobile {


### PR DESCRIPTION
https://github.com/cityofaustin/techstack/issues/1461

Pull down the branch, make sure the OPO department page looks good at any size. Nothing should be cut off or weirdly expanded. Full size, going down to tabletish, then mobile.

It could use some browser testing

Mobile:
- [ ] iPhone: Safari 12.0
- [ ] Android: Chrome 71.0

Desktop:
- [ ] Windows 10: Chrome 71.0
- [ ] Windows 7: Chrome 71.0
- [ ] MacOS 10.14: Chrome 71.0
- [ ] Windows 10: Edge 17.17