### PR TITLE
OPO Nav menu fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "axios": "^0.17.1",
     "babel-polyfill": "^6.26.0",
+    "body-scroll-lock": "^2.6.1",
     "browser-locale": "^1.0.3",
     "classnames": "^2.2.5",
     "downshift": "^1.31.15",

--- a/src/components/PageSections/Header/GovSite.js
+++ b/src/components/PageSections/Header/GovSite.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import DomeSVG from 'components/SVGs/Dome';
+import { misc as i18n1, navigation as i18n2 } from 'js/i18n/definitions';
+import { injectIntl } from 'react-intl';
+
+const GovSite = ({ intl, toggleHowYouKnowMenu, menuIsOpen }) => (
+  <div className="coa-Header__gov-site">
+    <div className="container-fluid wrapper">
+      <DomeSVG />
+      {intl.formatMessage(i18n1.coaOfficialWeb)}
+      <span className="coa-Header__gov-site-toggle" onClick={toggleHowYouKnowMenu}>
+        {menuIsOpen ? <i className="material-icons">remove</i> : <i className="material-icons">add</i>}
+      </span>
+    </div>
+  </div>
+);
+
+export default injectIntl(GovSite);

--- a/src/components/PageSections/Header/index.js
+++ b/src/components/PageSections/Header/index.js
@@ -14,6 +14,8 @@ import HowYouKnowMenu from 'components/PageSections/HowYouKnowMenu';
 import { themePropTypes } from 'components/PageSections/Menu/proptypes';
 import GovSite from 'components/PageSections/Header/GovSite';
 
+import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
+
 class Header extends Component {
   constructor(props) {
     super(props);
@@ -23,7 +25,17 @@ class Header extends Component {
     };
   }
 
+  componentDidMount() {
+    // 2. Get a target element that you want to persist scrolling for (such as a modal/lightbox/flyout/nav). 
+    this.menuElement = document.querySelector('#navMenu');
+  }
+
   toggleMenu = e => {
+    // If we're closing the menu, enable body scroll again
+    if(this.state.menuIsOpen) enableBodyScroll(this.targetElement);
+    // If we're opening the menu, disable body scroll
+    if(!this.state.menuIsOpen) disableBodyScroll(this.targetElement);
+
     this.setState({
       menuIsOpen: !this.state.menuIsOpen,
     });

--- a/src/components/PageSections/Header/index.js
+++ b/src/components/PageSections/Header/index.js
@@ -12,7 +12,7 @@ import LanguageSelectBar from 'components/PageSections/LanguageSelectBar';
 import Menu from 'components/PageSections/Menu';
 import HowYouKnowMenu from 'components/PageSections/HowYouKnowMenu';
 import { themePropTypes } from 'components/PageSections/Menu/proptypes';
-import DomeSVG from 'components/SVGs/Dome';
+import GovSite from 'components/PageSections/Header/GovSite';
 
 class Header extends Component {
   constructor(props) {
@@ -45,15 +45,7 @@ class Header extends Component {
         })}
         role="banner"
       >
-        <div className="coa-Header__gov-site">
-          <div className="container-fluid wrapper">
-            <DomeSVG />
-            {intl.formatMessage(i18n1.coaOfficialWeb)}
-            <span className="coa-Header__gov-site-toggle" onClick={this.toggleHowYouKnowMenu}>
-              {this.state.howYouKnowmenuIsOpen ? <i className="material-icons">remove</i> : <i className="material-icons">add</i>}
-            </span>
-          </div>
-        </div>
+        <GovSite toggleHowYouKnowMenu={this.toggleHowYouKnowMenu} menuIsOpen={this.state.howYouKnowmenuIsOpen}/>
         <div className="coa-Header__mobile-languages">
           <LanguageSelectBar path={path} />
         </div>
@@ -97,7 +89,7 @@ class Header extends Component {
           isMenuOpen={this.state.menuIsOpen}
           navigation={navigation}
         />
-        <HowYouKnowMenu open={this.state.howYouKnowmenuIsOpen} />
+        <HowYouKnowMenu open={this.state.howYouKnowmenuIsOpen} toggleHowYouKnowMenu={this.toggleHowYouKnowMenu}/>
       </header>
     );
   }

--- a/src/components/PageSections/HowYouKnowMenu/_HowYouKnowMenu.scss
+++ b/src/components/PageSections/HowYouKnowMenu/_HowYouKnowMenu.scss
@@ -2,7 +2,7 @@
   background: $coa-color-blue-darkest;
   display: none;
   position: fixed;
-  top: 3rem;
+  top: 0;
   width: 100vw;
 }
 

--- a/src/components/PageSections/HowYouKnowMenu/index.js
+++ b/src/components/PageSections/HowYouKnowMenu/index.js
@@ -3,11 +3,13 @@ import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import classNames from 'classnames';
 import GovSVG from 'components/SVGs/Gov';
+import GovSite from 'components/PageSections/Header/GovSite';
 
 import { howYouKnowMenu as i18n } from 'js/i18n/definitions';
 
-const HowYouKnowMenu = ({ open, intl }) => (
+const HowYouKnowMenu = ({ open, toggleHowYouKnowMenu, intl }) => (
   <div className={classNames('coa-HowYouKnowMenu', {'coa-HowYouKnowMenu--is-open': open})}>
+    <GovSite menuIsOpen={open} toggleHowYouKnowMenu={toggleHowYouKnowMenu} />
     <div className="container-fluid wrapper">
       <div className="coa-HowYouKnowMenu__info-blocks">
         <div className="coa-HowYouKnowMenu__info-block">

--- a/src/components/PageSections/Menu/_Menu.scss
+++ b/src/components/PageSections/Menu/_Menu.scss
@@ -12,7 +12,8 @@
     top: 8.5rem;
   }
   width: 100vw;
-  z-index: 2;
+  padding-bottom: 3rem;
+  // z-index: 2; This interacts badly with the gov site menu
   // @include media($coa-large-screen) {
   //   background: none;
   //   bottom: auto;
@@ -115,7 +116,7 @@
 .coa-Menu__subheading {
   text-transform: uppercase;
   font-size: 1.6rem;
-  padding-top: 4rem;
+  padding-top: 3rem;
   color: $coa-color-gray-dark;
   border-bottom: 2px solid $coa-color-half-primary;
   @include media($coa-medium-screen) {

--- a/src/components/PageSections/Menu/index.js
+++ b/src/components/PageSections/Menu/index.js
@@ -63,6 +63,7 @@ class Menu extends Component {
       <div className="container-fluid wrapper">
         <nav
           className={classNames('coa-Menu', { 'coa-Menu--open': isMenuOpen })}
+          id="navMenu"
           role="navigation"
         >
           <div className="container-fluid wrapper">

--- a/yarn.lock
+++ b/yarn.lock
@@ -2415,6 +2415,11 @@ body-parser@1.18.3:
     raw-body "2.3.3"
     type-is "~1.6.16"
 
+body-scroll-lock@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-2.6.1.tgz#3782ff37404886faaee366968ceee40c3964d8f2"
+  integrity sha512-fsDsq10+BJrk/+eGADqxspyZpGiKSh3dK8ByE6KuDK0REmPB99U05p1t9xVTAM9J6j9PJGm6W/W+HsCPnOFj+Q==
+
 bonjour@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bonjour/-/bonjour-3.5.0.tgz#8e890a183d8ee9a2393b3844c691a42bcf7bc9f5"


### PR DESCRIPTION
Addresses the issues in here: https://github.com/cityofaustin/techstack/issues/1534

* Fix bug: body of page scrolls behind menu when it's open.
* Fix bug: Header of gov site menu can be scrolled offscreen?
* Fix z-order: Since we can access the gov site button while the nav menu is open, it makes sense to make sure that the gov site menu goes on the tippy top
