### PR TITLE
fixes and updates style for back to dept link

### DIFF
--- a/src/components/Pages/_Information.scss
+++ b/src/components/Pages/_Information.scss
@@ -1,23 +1,37 @@
 .coa_InformationPage__back-to-dept {
-  a {
-    line-height: 6rem;
-    font-size: 1.7rem;
-    color: $coa-color-primary !important;
-    text-decoration: none !important;
-  }
-  span {
-    vertical-align: middle;
-    padding-left: .5rem;
-  }
   text-transform: uppercase;
   color: $coa-color-primary;
-  background: $coa-color-gray-lightest;
-  border-bottom: 1px solid $coa-color-half-primary;
+  background: $coa-color-grey;
+  border-bottom: none;
+
   @include media($coa-medium-screen) {
     background: $coa-color-white;
+    border-bottom: 1px solid $coa-color-half-primary;
+  }
+
+  a {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    padding: $coa-spacing-medium 0;
+    font-size: $coa-font-size-xsmall;
+    line-height: $coa-line-height-xsmall;
+    font-weight: $coa-font-bold;
+    color: $coa-color-primary !important;
+    text-decoration: none !important;
   }
 }
 
 .coa_InformationPage__arrow {
-  vertical-align: middle;
+  display: flex;
+  align-items: center;
+
+  &:after {
+    content: '';
+    border-left: 1px solid $coa-color-dark-grey;
+    vertical-align: middle;
+    height: $coa-font-size-large;
+    margin-left: $coa-spacing-md-small;
+    margin-right: $coa-spacing-md-small;
+  }
 }


### PR DESCRIPTION
Updated font-weight and styling (border btw arrow and text) per https://xd.adobe.com/spec/9770982d-46fa-472c-7726-37597101c397-e141/screen/a1f4dde3-1b46-4b09-9235-5028b52c9eee/DEMO-Information-MVP-mobile-1/

**BEFORE**
<img width="327" alt="Screen Shot 2019-03-21 at 12 56 04 PM" src="https://user-images.githubusercontent.com/3278040/54774005-c57f8a80-4bd8-11e9-819a-841d6dd6d581.png">
<img width="1206" alt="Screen Shot 2019-03-21 at 12 55 06 PM" src="https://user-images.githubusercontent.com/3278040/54774006-c57f8a80-4bd8-11e9-98e5-0c41f964c6a1.png">
.
.
.
.
.
**AFTER**
<img width="335" alt="Screen Shot 2019-03-21 at 12 56 12 PM" src="https://user-images.githubusercontent.com/3278040/54774033-d29c7980-4bd8-11e9-8683-17ab70eb2b60.png">
<img width="1162" alt="Screen Shot 2019-03-21 at 12 55 34 PM" src="https://user-images.githubusercontent.com/3278040/54774034-d29c7980-4bd8-11e9-873f-16620973e2c8.png">
