### PR TITLE
fixes mobile alignment and some styling tweaks

### DIFF
--- a/src/components/Pages/_Department.scss
+++ b/src/components/Pages/_Department.scss
@@ -69,45 +69,51 @@
 .coa-DepartmentPage__directorcard {
   display: flex;
   flex-direction: column;
+  align-items: center;
+  text-align: center;
+
   @include media($coa-medium-screen) {
+    text-align: initial;
     flex-direction: row;
   }
 }
 
 .coa-DepartmentPage__directorcard-name {
   color: $coa-color-primary;
-  font-size: 2.4rem;
   font-weight: normal;
+  margin-bottom: $coa-spacing-xsmall;
 }
 
 .coa-DepartmentPage__directorcard-title {
   font-size: 1.6rem;
   font-weight: bold;
+  line-height: $coa-line-height-small;
 }
 
 .coa-DepartmentPage__directorcard-coamaybe {
   font-size: 1.5rem;
-  line-height: 1.4rem;
+  line-height: $coa-line-height-xsmall;
 }
 
 .coa-DepartmentPage__directorcard-info {
-  margin-top: 5rem;
-  margin-right: 2.5rem;
-  margin-bottom: 2.5rem;
-  margin-left: 2.5rem;
+  margin-bottom: $coa-spacing-medium;
+
+  @include media($coa-medium-screen) {
+    margin-left: 2.5rem;
+    margin-bottom: 0;
+  }
 }
 
 .coa-DepartmentPage__directorcard-headshot {
   margin-left: auto;
   margin-right: auto;
+  margin-bottom: $coa-spacing-medium;
 
   @include media($coa-medium-screen) {
     margin-left: 0;
     margin-right: 0;
   }
 
-  width: 150px;
-  height: 150px;
   border-radius: 75px;
   overflow: hidden;
   margin-top: 2rem;


### PR DESCRIPTION
https://github.com/cityofaustin/techstack/issues/1334

- Addresses tablet image squishing
- Center alignment on mobile
- Spacing and line-height stuff


**BEFORE**

![Screen Shot 2019-03-25 at 9 32 20 AM](https://user-images.githubusercontent.com/3278040/54927875-06311980-4ee1-11e9-9f9d-b07548427510.png)
![Screen Shot 2019-03-25 at 9 31 56 AM](https://user-images.githubusercontent.com/3278040/54927877-06c9b000-4ee1-11e9-9b86-2f30172bc8bf.png)
![Screen Shot 2019-03-25 at 9 32 46 AM](https://user-images.githubusercontent.com/3278040/54927921-1b0dad00-4ee1-11e9-96b4-13307a6c185e.png)
.
.
.
.
.
.


**AFTER**

![Screen Shot 2019-03-25 at 9 32 55 AM](https://user-images.githubusercontent.com/3278040/54927964-2c56b980-4ee1-11e9-8e10-9fcd230fecf0.png)
![Screen Shot 2019-03-25 at 9 32 27 AM](https://user-images.githubusercontent.com/3278040/54927969-2e207d00-4ee1-11e9-8dc8-43519b3d68af.png)
![Screen Shot 2019-03-25 at 9 32 03 AM](https://user-images.githubusercontent.com/3278040/54927970-2eb91380-4ee1-11e9-8f56-fa1b11dc0f6e.png)
