### PR TITLE
Issue 1366: always display hours in CT

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "js-cookie": "^2.2.0",
     "lodash": "^4.17.4",
     "moment": "^2.20.1",
+    "moment-timezone": "^0.5.23",
     "node-sass-chokidar": "^0.0.3",
     "npm-run-all": "^4.1.2",
     "prop-types": "^15.6.0",

--- a/src/components/Contact/Hours.js
+++ b/src/components/Contact/Hours.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl, FormattedTime } from 'react-intl';
 import { findIndex, capitalize } from 'lodash';
-import moment from 'moment';
+import moment from 'moment-timezone';
 
 import { WEEKDAY_MAP } from 'js/helpers/constants';
 import { date as i18n1, contact as i18n2 } from 'js/i18n/definitions';
@@ -32,7 +32,7 @@ class Hours extends Component {
     } else {
       style = "ha";
     }
-    return moment(time).format(style);
+    return moment(time).tz('America/Chicago').format(style);
   }
 
   render() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7889,7 +7889,14 @@ module-deps@^4.0.8:
     through2 "^2.0.0"
     xtend "^4.0.0"
 
-moment@^2.20.1:
+moment-timezone@^0.5.23:
+  version "0.5.23"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.23.tgz#7cbb00db2c14c71b19303cb47b0fb0a6d8651463"
+  integrity sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0", moment@^2.20.1:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==


### PR DESCRIPTION
This should fix the issue for real.
Ref: https://github.com/cityofaustin/techstack/issues/1580

To test:
Run my Janis branch locally. Run in another timezone by using browserstack, a VPN, or flying to Cleveland. The OPO Office Hours should also display in Texas time (8am-5pm).

Easy peasy.