### PR TITLE
Fix Links

### DIFF
--- a/src/components/Tiles/Tile.js
+++ b/src/components/Tiles/Tile.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import I18nLink from 'components/I18n/I18nLink';
+import { Link } from 'react-static';
 
 import { tilePropTypes } from './proptypes';
 
 const Tile = ({ url, text }) => (
-  <I18nLink className="coa-Tile" to={url}>
+  <Link className="coa-Tile" to={url}>
     <div className="coa-Tile__content">
       <p className="coa-Tile__text">{text}</p>
       <i class="material-icons">arrow_forward</i>
     </div>
-  </I18nLink>
+  </Link>
 );
 
 Tile.propTypes = tilePropTypes;

--- a/src/components/Tiles/TileGroup.js
+++ b/src/components/Tiles/TileGroup.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import { services as i18n3 } from 'js/i18n/definitions';
-import I18nLink from 'components/I18n/I18nLink';
+import { Link } from 'react-static';
 import ArrowRight from 'components/SVGs/ArrowRight';
 
 import Tile from './Tile';
@@ -11,14 +11,14 @@ import { tileGroupPropTypes } from './proptypes';
 const TileGroup = ({ tiles, text, url, description, intl }) => (
   <div className="coa-TileGroup">
     <div className="wrapper container-fluid">
-      {text &&
-        url && (
-          <h4 className="coa-TileGroup__title">
-            <I18nLink to={url}>
-              {text}&nbsp;<ArrowRight />
-            </I18nLink>
-          </h4>
-        )}
+      {text && url && (
+        <h4 className="coa-TileGroup__title">
+          <Link to={url}>
+            {text}&nbsp;
+            <ArrowRight />
+          </Link>
+        </h4>
+      )}
 
       {text && !url && <h4 className="coa-TileGroup__title">{text}</h4>}
 

--- a/src/js/helpers/cleanData.js
+++ b/src/js/helpers/cleanData.js
@@ -54,7 +54,7 @@ export const cleanLinks = (links, pageType) => {
     var pathPrefix = '';
     if (pageType === 'service') {
       // Service page links are always theme/topic based
-      pathPrefix = `${link.topic.theme.slug}/${link.topic.slug}`
+      pathPrefix = `/${link.topic.theme.slug}/${link.topic.slug}`;
     }
 
     link.slug = link.slug || link.sortOrder;


### PR DESCRIPTION
Implement quick fix for broken link internationalization, by replacing i18n links with react-static links. I found that we keep the language selection while the address bar loses it, but the links work this way.?

Not a perfect solution, but should do the trick in the short term. More info here: https://github.com/cityofaustin/techstack/issues/1649