### PR TITLE
temp container, add actual grey color from design specs, relative + z-index

### DIFF
--- a/src/components/HeroHome/_HeroHome.scss
+++ b/src/components/HeroHome/_HeroHome.scss
@@ -1,7 +1,7 @@
 .coa-HeroHome__container {
   img {
     position: absolute;
-    z-index: -1;
+    z-index: 0;
     top: 0px;
     height: $coa-herohome-height--default;
     width: 100%;

--- a/src/components/PageNotificationBanner/_PageNotificationBanner.scss
+++ b/src/components/PageNotificationBanner/_PageNotificationBanner.scss
@@ -1,8 +1,8 @@
 .coa-PageNotificationBanner {
   // Commenting out because it's causing issues on the homepage
   // that will be addressed in: https://github.com/cityofaustin/techstack/issues/1796
-  // background-color: $coa-color-gray-lightest;
-  background-color: $coa-color-white;
+  background-color: $coa-color-gray-spec;
+  // background-color: $coa-color-white;
   margin-top: 3rem;
   @include media($coa-medium-screen) {
     margin-top: 0;

--- a/src/components/Pages/Home.js
+++ b/src/components/Pages/Home.js
@@ -16,18 +16,19 @@ const Home = ({ topServices, image, intl }) => (
     <Head>
       <title>{'City of Austin'}</title>
     </Head>
-
     <HeroHome
       imageFilename={`${process.env.CMS_MEDIA}/images/${image.file}`}
       imageTitle={image.title}
       preheader={intl.formatMessage(i18n2.welcomeTo)}
     />
-    <TopServices
-      title={intl.formatMessage(i18n3.checkOutServices)}
-      tiles={topServices}
-      locale={intl.locale}
-      extraClasses={'floating'}
-    />
+    <div style={{ backgroundColor: `#f0f0f0` }}>
+      <TopServices
+        title={intl.formatMessage(i18n3.checkOutServices)}
+        tiles={topServices}
+        locale={intl.locale}
+        extraClasses={'floating'}
+      />
+    </div>
     <PageNotificationBanner>
       <WorkInProgress />
     </PageNotificationBanner>

--- a/src/components/Tiles/_TopServices.scss
+++ b/src/components/Tiles/_TopServices.scss
@@ -1,4 +1,6 @@
 .coa-TopServices {
+  position: relative;
+  z-index: 2;
   &.floating {
     padding: 2rem 0;
     margin-left: 2rem;

--- a/src/css/base/_variables.scss
+++ b/src/css/base/_variables.scss
@@ -99,6 +99,7 @@ $coa-color-purple: #372145;
 $coa-color-purple-dark: #240b33;
 $coa-color-purple-darkest: #170821;
 
+$coa-color-gray-spec: #f0f0f0;
 $coa-color-gray-lightest: #f4f4f4;
 $coa-color-gray-lighter: #eaeaea;
 $coa-color-gray-light: #cbcbcb;


### PR DESCRIPTION
* the gray lightest dosen't _quite_ match the grey @chasechenevert had in his spec. I added it to variables with a temp variable name for discussion. 
* I just made a temp container to get the background color in place, as it looks like we may be altering the home page to add in the footer(s) so this may be temporary