### PR TITLE
2656-Update _ContextualNav.scss

### DIFF
--- a/src/components/PageSections/ContextualNav/_ContextualNav.scss
+++ b/src/components/PageSections/ContextualNav/_ContextualNav.scss
@@ -11,7 +11,7 @@
 .coa-ContextualNav__container {
   display: flex;
   flex-direction: row;
-  align-items: center;
+  align-items: normal;
 }
 
 .coa-ContextualNav__parent {


### PR DESCRIPTION
Parent link aligns to top instead of center, creating parity with other links in ContextualNav.

https://github.com/cityofaustin/techstack/issues/2565