### PR TITLE
Issue 2773: translate labels for official documents page

### DIFF
--- a/src/components/Pages/OfficialDocument.js
+++ b/src/components/Pages/OfficialDocument.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import moment from 'moment-timezone';
 
+import { officialdocuments as i18n } from 'js/i18n/definitions';
+
 const OfficialDocument = ({ document: { id, date, title, authoringOffice, summary, name, link, pdfSize }, intl }) => {
   // If the link is a PDF with a pdfSize, then include it.
   const pdfComponent = (!!pdfSize) ?
@@ -17,10 +19,10 @@ const OfficialDocument = ({ document: { id, date, title, authoringOffice, summar
       <h2 className="coa-OfficialDocumentPage__title">{title}</h2>
       <p>{summary}</p>
       <div className="coa-OfficialDocumentPage__small-heading-container">
-        <span className="coa-OfficialDocumentPage__small-heading">Author:</span> {authoringOffice}
+        <span className="coa-OfficialDocumentPage__small-heading">{intl.formatMessage(i18n.author)}:</span> {authoringOffice}
       </div>
       <div className="coa-OfficialDocumentPage__small-heading-container">
-        <span className="coa-OfficialDocumentPage__small-heading">Document:</span> <a href={link}>{name}</a> {pdfComponent}
+        <span className="coa-OfficialDocumentPage__small-heading">{intl.formatMessage(i18n.document)}:</span> <a href={link}>{name}</a> {pdfComponent}
       </div>
     </div>
   );

--- a/src/js/i18n/definitions.js
+++ b/src/js/i18n/definitions.js
@@ -462,3 +462,8 @@ export const footerSiteMapMenu = defineMessages([
     ],
   },
 ]);
+
+export const officialdocuments = defineMessages({
+  author: 'Author',
+  document: 'Document',
+});

--- a/src/js/i18n/locales/ar.json
+++ b/src/js/i18n/locales/ar.json
@@ -45,5 +45,7 @@
   "threeoneone.all311": "جميع خدمات 311",
   "threeoneone.call311": "",
   "threeoneone.contact311": "",
-  "topics.topic": ""
+  "topics.topic": "",
+  "officialdocuments.author": "",
+  "officialdocuments.document": ""
 }

--- a/src/js/i18n/locales/en.json
+++ b/src/js/i18n/locales/en.json
@@ -88,5 +88,7 @@
   "howYouKnowMenu.dotGovHeader": "The .gov means it’s official.",
   "howYouKnowMenu.dotGovText": "Government websites often end in .gov. Before sharing sensitive information, make sure you’re on a government site.",
   "howYouKnowMenu.httpsHeader": "The site is secure.",
-  "howYouKnowMenu.httpsText": "The https:// ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely."
+  "howYouKnowMenu.httpsText": "The https:// ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely.",
+  "officialdocuments.author": "Author",
+  "officialdocuments.document": "Document"
 }

--- a/src/js/i18n/locales/es.json
+++ b/src/js/i18n/locales/es.json
@@ -86,5 +86,7 @@
   "departmentPage.meetDirector": "Conozca a nuestra directora",
   "departmentPage.topServices": "Servicios principales",
   "departmentPage.yourDataLinkText": "Cómo almacenamos y usamos su información",
-  "departmentPage.investigationProcessLinkText": "Proceso de investigación de quejas"
+  "departmentPage.investigationProcessLinkText": "Proceso de investigación de quejas",
+  "officialdocuments.author": "Autor",
+  "officialdocuments.document": "Documento"
 }

--- a/src/js/i18n/locales/vi.json
+++ b/src/js/i18n/locales/vi.json
@@ -45,5 +45,7 @@
   "threeoneone.all311": "Tất cả các dịch vụ 311",
   "threeoneone.call311": "",
   "threeoneone.contact311": "",
-  "topics.topic": ""
+  "topics.topic": "",
+  "officialdocuments.author": "",
+  "officialdocuments.document": ""
 }


### PR DESCRIPTION
Ref: https://github.com/cityofaustin/techstack/issues/2773

Acceptance Criteria: make sure *Author:* and *Document:* on official documents page are translated into spanish.