### PR TITLE
markdown broken link on readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🌻 Janis ☮️
 
-Janis is the codename for the software that renders [https://alpha.austin.gov](alpha.austin.gov) for web browsers. It is a working prototype of static site generation front-end and decoupled CMS architecture.
+Janis is the codename for the software that renders [alpha.austin.gov](https://alpha.austin.gov) for web browsers. It is a working prototype of static site generation front-end and decoupled CMS architecture.
 
 Janis uses data provided by the CMS API service, [Joplin](https://github.com/cityofaustin/joplin), along with the React components to generate a static-progressive website.
 


### PR DESCRIPTION
The Bug: Clicking the website link on the `readme.md` takes you to github's star-wars *404* error

The fix: Just need to swap the `(link)` with the `[name]` in the markdown

<img width="919" alt="Screen Shot 2019-09-06 at 4 17 44 PM" src="https://user-images.githubusercontent.com/15821138/64461343-8d0a3500-d0c2-11e9-95b5-ad223ba4788f.png">
