### PR TITLE
2662 Service page step styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # 🌻 Janis ☮️
- 
+
 Janis is the codename for the software that renders [alpha.austin.gov](https://alpha.austin.gov) for web browsers. It is a working prototype of static site generation front-end and decoupled CMS architecture.
 
 Janis uses data provided by the CMS API service, [Joplin](https://github.com/cityofaustin/joplin), along with the React components to generate a static-progressive website.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # 🌻 Janis ☮️
-
+ 
 Janis is the codename for the software that renders [alpha.austin.gov](https://alpha.austin.gov) for web browsers. It is a working prototype of static site generation front-end and decoupled CMS architecture.
 
 Janis uses data provided by the CMS API service, [Joplin](https://github.com/cityofaustin/joplin), along with the React components to generate a static-progressive website.

--- a/scripts/build-joplin-cloud.sh
+++ b/scripts/build-joplin-cloud.sh
@@ -18,4 +18,8 @@ if [ "$HEAD" == '2666-hacky-janis-step-apps' ]; then
   export CMS_API='https://joplin-staging.herokuapp.com/api/graphql'
 fi
 
+if [ "$HEAD" == '2662-service-step-styling' ]; then
+  export CMS_API='https://joplin-pr-2662-service-step-st.herokuapp.com/api/graphql'
+fi
+
 yarn npm-run-all build-css build-js

--- a/scripts/build-joplin-cloud.sh
+++ b/scripts/build-joplin-cloud.sh
@@ -18,8 +18,8 @@ if [ "$HEAD" == '2666-hacky-janis-step-apps' ]; then
   export CMS_API='https://joplin-staging.herokuapp.com/api/graphql'
 fi
 
-# if [ "$HEAD" == '2662-service-step-styling' ]; then
-#   export CMS_API='https://joplin-pr-2662-service-step-st.herokuapp.com/api/graphql'
-# fi
+if [ "$HEAD" == '2662-service-step-styling' ]; then
+  export CMS_API='https://joplin-pr-2662-service-step-st.herokuapp.com/api/graphql'
+fi
 
 yarn npm-run-all build-css build-js

--- a/scripts/build-joplin-cloud.sh
+++ b/scripts/build-joplin-cloud.sh
@@ -18,8 +18,8 @@ if [ "$HEAD" == '2666-hacky-janis-step-apps' ]; then
   export CMS_API='https://joplin-staging.herokuapp.com/api/graphql'
 fi
 
-if [ "$HEAD" == '2662-service-step-styling' ]; then
-  export CMS_API='https://joplin-pr-2662-service-step-st.herokuapp.com/api/graphql'
-fi
+# if [ "$HEAD" == '2662-service-step-styling' ]; then
+#   export CMS_API='https://joplin-pr-2662-service-step-st.herokuapp.com/api/graphql'
+# fi
 
 yarn npm-run-all build-css build-js

--- a/src/components/Steps/StepWithOptions.js
+++ b/src/components/Steps/StepWithOptions.js
@@ -43,8 +43,8 @@ StepOption.propTypes = optionPropTypes;
 
 const StepWithOptionsContent = props => (
   <div className="coa-StepOption__container">
-    <h1 className="coa-StepOption__title">{props.description}</h1>
-    <Accordion className={'coa-Accordion'} allowMultipleExpanded={false}>
+    <HtmlFromAdmin content={props.description} />
+    <Accordion className={'coa-Accordion testy'} allowMultipleExpanded={false}>
       {props.options.map(({ ...rest }, index) => (
         <StepOption key={index} {...rest} />
       ))}

--- a/src/components/Steps/StepWithOptions.js
+++ b/src/components/Steps/StepWithOptions.js
@@ -18,7 +18,6 @@ const StepOption = ({ option_name, option_description }) => (
       <AccordionItemHeading className={'coa-AccordionItemHeading'}>
         <AccordionItemButton className={'coa-AccordionButton'}>
           <h3 className="coa-StepOption__name">{option_name}</h3>
-
           <AccordionItemState>
             {({ expanded }) =>
               expanded ? (

--- a/src/components/Steps/StepWithOptions.js
+++ b/src/components/Steps/StepWithOptions.js
@@ -43,7 +43,7 @@ StepOption.propTypes = optionPropTypes;
 const StepWithOptionsContent = props => (
   <div className="coa-StepOption__container">
     <HtmlFromAdmin content={props.description} />
-    <Accordion className={'coa-Accordion testy'} allowMultipleExpanded={false}>
+    <Accordion className={'coa-Accordion'} allowMultipleExpanded={false}>
       {props.options.map(({ ...rest }, index) => (
         <StepOption key={index} {...rest} />
       ))}

--- a/src/components/Steps/_StepOption.scss
+++ b/src/components/Steps/_StepOption.scss
@@ -29,6 +29,7 @@
 
 .coa-Accordion {
   flex: 1;
+  margin-top: 3rem;
 }
 
 .coa-AccordionItem {


### PR DESCRIPTION
This is the "Janis" part of issue #2662. 
- see: ["Joplin" pull request](https://github.com/cityofaustin/joplin/pull/360)
- deployed: https://deploy-preview-501--janis.netlify.com/en/health-safety/health-records-certificates-2/birth-death-certificates/birth-and-death-certificates-test

The  header for the "Basic steps" and the "Steps with Options" was styled differently, so we decided to go with removing the "Steps with Options" header tag `h1` tag from the style.
- *Note:* I used the `HtmlFromAdmin` component to hold the content that may want to be styled by rich text in the future. Now, the styling is just default.

<img width="1306" alt="Screen Shot 2019-09-09 at 12 29 30 PM" src="https://user-images.githubusercontent.com/15821138/64553005-2b360f00-d2fe-11e9-997b-414f90fa80e6.png">
