### PR TITLE
2904 centered TOC btn andriod

### DIFF
--- a/scripts/build-joplin-cloud.sh
+++ b/scripts/build-joplin-cloud.sh
@@ -18,7 +18,7 @@ if [ "$HEAD" == '2937-windows-scrollbars' ]; then
   export CMS_API='https://joplin-staging.herokuapp.com/api/graphql'
 fi
 
-if [ "$HEAD" == '2939-arrows' ]; then
+if [ "$HEAD" == '2904-andriod-ToC' ]; then
   export CMS_API='https://joplin-staging.herokuapp.com/api/graphql'
 fi
 

--- a/src/components/Pages/Guide/_Guide.scss
+++ b/src/components/Pages/Guide/_Guide.scss
@@ -259,6 +259,10 @@ $max-guide-tablet-width: $coa-medium-screen;
   width: 100%;
 }
 
+.coa-GuidePage__content-container > .wrapper > .row {
+  margin-right: 0 !important;
+}
+
 .coa-GuideMenu__mobile-button {
   position: relative;
   display: flex;

--- a/src/components/Pages/Guide/_Guide.scss
+++ b/src/components/Pages/Guide/_Guide.scss
@@ -58,7 +58,7 @@ $max-guide-tablet-width: $coa-medium-screen;
 .coa-GuidePage__main-content {
   @extend .col-xs-12;
   @extend .col-lg-8;
-
+  padding-right: 0; //TODO: again, uswds's default .row class has built in -1rem margins!!
   margin-top: $sticky-guide-top;
 }
 
@@ -260,7 +260,7 @@ $max-guide-tablet-width: $coa-medium-screen;
 }
 
 .coa-GuidePage__content-container > .wrapper > .row {
-  margin-right: 0 !important;
+  margin-right: 0; //TODO: again, uswds's default .row class has built in -1rem margins!!
 }
 
 .coa-GuideMenu__mobile-button {


### PR DESCRIPTION
fixes: https://github.com/cityofaustin/techstack/issues/2904
deployed: https://deploy-preview-515--janis.netlify.com/

What I did: 
- It looks like android devices want to add their own padding to "row" classes. 
- setting the right margin to 0 looks to clean this up and won't effect IOs or other browsers. 