### PR TITLE
2892 Guide content is broken on IE 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # sass to css
 src/**/*.css
+
+# react-static
+artifacts/

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "start-prod": "./scripts/serve-local.sh -P",
     "start": "npm-run-all -p watch-css start-js",
     "build": "npm-run-all build-css build-js && cp -r dist/* _dist/",
+    "build-local": "bash ./scripts/build-local.sh",
     "build-joplin-cloud": "bash ./scripts/build-joplin-cloud.sh",
     "start-js": "react-static start",
     "build-js": "react-static build",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "start-prod": "./scripts/serve-local.sh -P",
     "start": "npm-run-all -p watch-css start-js",
     "build": "npm-run-all build-css build-js && cp -r dist/* _dist/",
-    "build-local": "bash ./scripts/build-local.sh",
+    "build-local-ie": "bash ./scripts/build-local-ie.sh",
     "build-joplin-cloud": "bash ./scripts/build-joplin-cloud.sh",
     "start-js": "react-static start",
     "build-js": "react-static build",

--- a/scripts/build-local-ie.sh
+++ b/scripts/build-local-ie.sh
@@ -1,4 +1,8 @@
-export NODE_PATH='./src'
+# IE11 can't be served from webpack-dev-server
+# So we can use this script to build a static site and write it to the dist folder.
+# This allows us to develop and test IE11 on Browserstack locally.
+CD=`dirname $BASH_SOURCE`
+export NODE_PATH="$CD/../src"
 
 export CMS_API='https://joplin-staging.herokuapp.com/api/graphql'
 export CMS_MEDIA='https://joplin-austin-gov-static.s3.amazonaws.com/production/media'

--- a/scripts/build-local-ie.sh
+++ b/scripts/build-local-ie.sh
@@ -1,8 +1,7 @@
 # IE11 can't be served from webpack-dev-server
 # So we can use this script to build a static site and write it to the dist folder.
 # This allows us to develop and test IE11 on Browserstack locally.
-CD=`dirname $BASH_SOURCE`
-export NODE_PATH="$CD/../src"
+export NODE_PATH='./src'
 
 export CMS_API='https://joplin-staging.herokuapp.com/api/graphql'
 export CMS_MEDIA='https://joplin-austin-gov-static.s3.amazonaws.com/production/media'

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -1,0 +1,10 @@
+export NODE_PATH='./src'
+
+export CMS_API='https://joplin-staging.herokuapp.com/api/graphql'
+export CMS_MEDIA='https://joplin-austin-gov-static.s3.amazonaws.com/production/media'
+
+yarn npm-run-all build-css build-js
+
+echo " 🏗 END of the Build 🏗 "
+
+http-server dist

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -8,3 +8,5 @@ yarn npm-run-all build-css build-js
 echo " 🏗 END of the Build 🏗 "
 
 http-server dist
+
+say "Hello O.D.D. Developer, I'm done building the application."

--- a/src/components/Pages/Guide/_Guide.scss
+++ b/src/components/Pages/Guide/_Guide.scss
@@ -363,3 +363,22 @@ $max-guide-tablet-width: $coa-medium-screen;
     margin: auto;
   }
 }
+
+@media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
+   /*
+     - IE10+ specific styles go here
+     - https://paper-leaf.com/blog/2014/09/targeting-ie-10-11-browsers-css/
+   */
+
+   .coa-GuidePage__content-container {
+     display: block;
+   }
+
+   .coa-GuidePage__content-container > .wrapper > .row {
+     //display: block;
+     // flex: 1;
+   }
+   // .coa-GuidePage__main-content {
+   //   margin-left: 33.33%;
+   // }
+}

--- a/src/components/Pages/Guide/_Guide.scss
+++ b/src/components/Pages/Guide/_Guide.scss
@@ -365,20 +365,11 @@ $max-guide-tablet-width: $coa-medium-screen;
 }
 
 @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
-   /*
-     - IE10+ specific styles go here
-     - https://paper-leaf.com/blog/2014/09/targeting-ie-10-11-browsers-css/
-   */
-
+  /*
+    This CSS section is for conditional styling for IE 11 only.
+  */
    .coa-GuidePage__content-container {
+     // IE 11 dosn't play nice with flex-box. Here we can override "display: flex" and preserve flex for all other browsers.
      display: block;
    }
-
-   .coa-GuidePage__content-container > .wrapper > .row {
-     //display: block;
-     // flex: 1;
-   }
-   // .coa-GuidePage__main-content {
-   //   margin-left: 33.33%;
-   // }
 }

--- a/src/components/Pages/Guide/helpers.js
+++ b/src/components/Pages/Guide/helpers.js
@@ -2,15 +2,15 @@
 export const hyphenate = (title) => title.replace(/\s/g, "-")
 
 // useful for debugging the sidebar
-export const printSections = (sectionLocations, scrollY) => {
+export const printSections = (sectionLocations, pageYOffset) => {
   console.log("-----------------------------------------")
   let gotY = false;
   for (let i in sectionLocations) {
     let section = sectionLocations[i];
-    if (!gotY && (scrollY < (section.offsetTop - 1))) {
+    if (!gotY && (pageYOffset < (section.offsetTop - 1))) {
       gotY = true;
       console.log("|")
-      console.log(`x <---- we are here at ${scrollY}`);
+      console.log(`x <---- we are here at ${pageYOffset}`);
       console.log ("|")
     } else {
       console.log ("|")
@@ -19,7 +19,7 @@ export const printSections = (sectionLocations, scrollY) => {
   }
   if (!gotY) {
     console.log ("|")
-    console.log(`x <---- we are here at ${scrollY}`);
+    console.log(`x <---- we are here at ${pageYOffset}`);
     console.log ("|")
   } else {
     console.log ("|")

--- a/src/components/Pages/Guide/index.js
+++ b/src/components/Pages/Guide/index.js
@@ -59,6 +59,7 @@ function Guide(props) {
     We want the GuideSection right before the first GuideSection that is past the window's position.
   **/
   function handleScroll() {
+    // printSections(sectionLocations, window.pageYOffset)
     let i = 0;
     while (i < sectionLocations.length) {
       if (window.pageYOffset < sectionLocations[i].offsetTop - 1) {

--- a/src/components/Pages/Guide/index.js
+++ b/src/components/Pages/Guide/index.js
@@ -44,6 +44,7 @@ function Guide(props) {
 
   // Update offsetTop of each GuideSection if the window resizes
   function updateSectionLocation(offsetTop, anchorTag) {
+    console.log("offsetTop, anchorTag :", offsetTop, anchorTag)
     return dispatchSectionLocations({
       action: 'update',
       payload: { offsetTop, anchorTag },
@@ -62,6 +63,7 @@ function Guide(props) {
     let i = 0;
     while (i < sectionLocations.length) {
       if (window.scrollY < sectionLocations[i].offsetTop - 1) {
+        console.log('Its this section!!!',sectionLocations[i])
         break;
       } else {
         i++;

--- a/src/components/Pages/Guide/index.js
+++ b/src/components/Pages/Guide/index.js
@@ -13,6 +13,7 @@ import PageBanner from 'components/PageBanner';
 import GuideMenuMobile from 'components/Pages/Guide/GuideMenuMobile';
 import GuideMenu from 'components/Pages/Guide/GuideMenu';
 import { isMobileOrTabletQuery } from 'js/helpers/reactMediaQueries';
+import { printSections } from 'components/Pages/Guide/helpers.js'
 
 function Guide(props) {
   const [currentSection, setCurrentSection] = useState(null);
@@ -44,7 +45,6 @@ function Guide(props) {
 
   // Update offsetTop of each GuideSection if the window resizes
   function updateSectionLocation(offsetTop, anchorTag) {
-    console.log("offsetTop, anchorTag :", offsetTop, anchorTag)
     return dispatchSectionLocations({
       action: 'update',
       payload: { offsetTop, anchorTag },
@@ -59,18 +59,15 @@ function Guide(props) {
     We want the GuideSection right before the first GuideSection that is past the window's position.
   **/
   function handleScroll() {
-    const thing = sectionLocations[0].offsetTop;
     let i = 0;
     while (i < sectionLocations.length) {
-      if (window.scrollY < sectionLocations[i].offsetTop - 1) {
-        console.log('Its this section!!!',sectionLocations[i])
+      if (window.pageYOffset < sectionLocations[i].offsetTop - 1) {
         break;
       } else {
         i++;
       }
     }
     i--;
-
     const nextCurrentSection = sectionLocations[i];
     if (nextCurrentSection) {
       setCurrentSection(nextCurrentSection.anchorTag);


### PR DESCRIPTION
This fixes #2892 Guide errors on IE 11
- Issue: https://app.zenhub.com/workspaces/techstack-5a78b88e1ce69f3510b678ef/issues/cityofaustin/techstack/2892
- [x] - IE 11 Guide positioning error
  - IE is finicky with `display: flex`. `block` for just IE 11 will patch this error. 
- [x] - IE 11 Guide tracking tabs error
  - IE draws `undefined` for window.scrollY. Use `window.pageYOffset` instead

Additionally.. I build a script for IE testing!
- This will add the script command with yarn: `yarn build-local`, which will build, serve and alert developer that it's done, because it takes so long....
  - @Niicck feel free to wipe/modify this in your PR build adventures

- Dependency required: `http-server`
  - You can install simply with npm by running `http-server -g http-server`

Reference: 
- https://developer.mozilla.org/it/docs/Web/API/Window/scrollX
