### PR TITLE
3056 fix topic page previews

### DIFF
--- a/src/components/_Controllers/CMSPreview.js
+++ b/src/components/_Controllers/CMSPreview.js
@@ -13,7 +13,7 @@ import getOfficialDocumentPageRevisionQuery from 'js/queries/getOfficialDocument
 import {
   cleanServicesForPreview,
   cleanInformationForPreview,
-  cleanTopics,
+  cleanTopicsForPreview,
   cleanDepartments,
   cleanTopicCollections,
   cleanOfficialDocumentPagesForPreview,
@@ -139,16 +139,16 @@ class CMSPreview extends Component {
         <Route
           path="/topic"
           render={props => {
-            let topic = cleanTopics(data)[0];
+            let topic = cleanTopicsForPreview(data)[0];
             topic.topLinks = [
-              { text: 'Top link', url: '' },
-              { text: 'Other top link', url: '' },
+              { title: 'Top link', url: '' },
+              { title: 'Other top link', url: '' },
             ];
             topic.otherLinks = [
-              { text: 'First link', url: '' },
-              { text: 'Second link', url: '' },
-              { text: 'Third link', url: '' },
-              { text: 'Fourth link', url: '' },
+              { title: 'First link', url: '' },
+              { title: 'Second link', url: '' },
+              { title: 'Third link', url: '' },
+              { title: 'Fourth link', url: '' },
             ];
             topic.topiccollection = { topics: [], theme: {} };
 
@@ -173,7 +173,11 @@ class CMSPreview extends Component {
         <Route
           path="/official_document"
           render={props => (
-              <OfficialDocumentList officialDocumentPage={cleanOfficialDocumentPagesForPreview(data)[0]} />
+            <OfficialDocumentList
+              officialDocumentPage={
+                cleanOfficialDocumentPagesForPreview(data)[0]
+              }
+            />
           )}
         />
       </Switch>

--- a/src/js/helpers/cleanData.js
+++ b/src/js/helpers/cleanData.js
@@ -382,6 +382,17 @@ export const cleanDepartments = (allDepartments, langCode) => {
   });
 };
 
+export const cleanTopicsForPreview = allTopics => {
+  if (!allTopics || !allTopics.edges) return null;
+
+  const cleanedTopics = allTopics.edges.map(edge => ({
+    text: edge.node.title,
+    ...edge.node,
+  }));
+
+  return cleanedTopics;
+};
+
 export const cleanTopics = allTopics => {
   if (!allTopics || !allTopics.edges) return null;
 


### PR DESCRIPTION
## What this does
* Make it so topic page previews load, and title/description can be previewed

## What this doesn't do
* Make it so we don't use dummy data to populate page links in the preview