### PR TITLE
Style updates to Trashy & ReCollect

### DIFF
--- a/src/components/Recollect/_Recollect.scss
+++ b/src/components/Recollect/_Recollect.scss
@@ -82,7 +82,7 @@
           font-size: $coa-font-size-small;
           font-weight: $coa-font-bold;
           padding: 0 0 $coa-spacing-small;
-          text-transform: uppercase;
+          text-transform: none;
         }
         & > .rCsearch[data-type='Address'],
         & > .rCsearch[data-type='Material'] {

--- a/src/components/Recollect/_Recollect.scss
+++ b/src/components/Recollect/_Recollect.scss
@@ -5,12 +5,12 @@
     border-color: $coa-color-gray;
   }
   .widget-header {
-    background: $coa-color-purple-darkest;
+    background: $coa-color-dark-blue;
     #rCw-title {
       font-size: $coa-font-size-xsmall !important;
       font-weight: $coa-font-bold;
       line-height: $coa-line-height-large;
-      text-transform: uppercase;
+      text-transform: none;
     }
     #recollect-social {
       display: none !important;
@@ -46,6 +46,7 @@
           background: none;
           border: none;
           border-radius: 0;
+          color: $coa-color-primary;
           display: flex;
           height: 100%;
           justify-content: center;
@@ -107,9 +108,10 @@
             }
             #rCbtn-search {
               align-items: center;
-              background-color: $coa-color-blue;
+              background-color: $coa-color-primary;
               border: none;
               border-radius: $coa-button-border-radius;
+              color: $coa-color-white;
               display: flex;
               flex-basis: 100%;
               font-size: $coa-font-size-small;
@@ -143,5 +145,10 @@
   .rC-footer .rC-powered {
     line-height: $coa-line-height-xsmall;
     padding: 0;
+  }
+  .rC-left-link {
+    a {
+      color: $coa-color-primary;
+    }
   }
 }

--- a/src/components/Trashy/TrashyAddress.js
+++ b/src/components/Trashy/TrashyAddress.js
@@ -34,10 +34,12 @@ const TrashyAddress = ({ suggestions, setAddress, getSuggestions, intl }) => (
           })}
         />
         {selectedItem && (
-          <CloseSVG
+          <div
             className="coa-Trashy__autosuggestion-clear"
             onClick={clearSelection}
-          />
+          >
+            <i className="material-icons">close</i>
+          </div>
         )}
         {isOpen ? (
           <div>


### PR DESCRIPTION
[Issue #2951](https://github.com/cityofaustin/techstack/issues/2951)

I replaced the "X" close icon with Material's close in Trashy.

I updated the color button color and banner color to match the acceptance criteria as well as the "List of Materials" link in the footer. However, I couldn't update the link colors in the search results because they are contained in an iFrame. The secondary buttons are also in the iFrame. 

When the copy is in Spanish, it appears correctly in sentence case, but when it is in English it appears as "What Do I Do With" which seems to come with that capitalization from the widget. 