### PR TITLE
3065 Guide anchor links needs slowing down—better solution

### DIFF
--- a/scripts/build-joplin-cloud.sh
+++ b/scripts/build-joplin-cloud.sh
@@ -5,7 +5,7 @@ export CMS_API='https://joplin.herokuapp.com/api/graphql'
 export CMS_MEDIA='https://joplin-austin-gov.s3.amazonaws.com/media'
 export CMS_DOCS='multiple'
 
-if [ "$HEAD" == '2906-toc-horizontal-rules' ]; then
+if [ "$HEAD" == '3065-scroll-fix' ]; then
   export CMS_API='https://joplin-staging.herokuapp.com/api/graphql'
 fi
 
@@ -13,9 +13,5 @@ fi
 # if [ "$HEAD" == '2662-service-step-styling' ]; then
 #   export CMS_API='https://joplin-pr-2662-service-step-st.herokuapp.com/api/graphql'
 # fi
-
-if [ "$HEAD" == '2473-preview-topics' ]; then
-  export CMS_API='https://joplin-pr-3082-guide-page-prev.herokuapp.com/api/graphql'
-fi
 
 yarn npm-run-all build-css build-js

--- a/src/components/Pages/Guide/GuideMenu.js
+++ b/src/components/Pages/Guide/GuideMenu.js
@@ -7,8 +7,17 @@ import { isMobileOrTablet } from 'js/helpers/reactMediaQueries';
 function GuideMenuLink({ title, anchorTag, isHeading, isCurrentSection }) {
   // Each GuideSectionWrapper has an id={this.props.anchorTag}
   function goToSection(e) {
-    e.preventDefault();
-    window.location.href = `#${anchorTag}`;
+    // console.log('\n\nclick: go to', anchorTag)
+    // e.preventDefault();
+    // window.location.href = `#${anchorTag}`;
+
+    window.requestAnimationFrame(function(){
+        console.log('\n\nclick: go to', anchorTag)
+        // e.preventDefault();
+        // window.location.href = `#${anchorTag}`;
+        document.getElementById(anchorTag).scrollIntoView(true);
+
+    })
   }
 
   return (

--- a/src/components/Pages/Guide/GuideMenu.js
+++ b/src/components/Pages/Guide/GuideMenu.js
@@ -7,6 +7,7 @@ import { isMobileOrTablet } from 'js/helpers/reactMediaQueries';
 function GuideMenuLink({ title, anchorTag, isHeading, isCurrentSection }) {
   // Each GuideSectionWrapper has an id={this.props.anchorTag}
   function goToSection(e) {
+    history.pushState(null, null, `#${anchorTag}`);
     document.getElementById(anchorTag).scrollIntoView(true);
   }
 

--- a/src/components/Pages/Guide/GuideMenu.js
+++ b/src/components/Pages/Guide/GuideMenu.js
@@ -7,17 +7,7 @@ import { isMobileOrTablet } from 'js/helpers/reactMediaQueries';
 function GuideMenuLink({ title, anchorTag, isHeading, isCurrentSection }) {
   // Each GuideSectionWrapper has an id={this.props.anchorTag}
   function goToSection(e) {
-    // console.log('\n\nclick: go to', anchorTag)
-    // e.preventDefault();
-    // window.location.href = `#${anchorTag}`;
-
-    window.requestAnimationFrame(function(){
-        console.log('\n\nclick: go to', anchorTag)
-        // e.preventDefault();
-        // window.location.href = `#${anchorTag}`;
-        document.getElementById(anchorTag).scrollIntoView(true);
-
-    })
+    document.getElementById(anchorTag).scrollIntoView(true);
   }
 
   return (

--- a/src/components/Pages/Guide/GuideSectionWrapper.js
+++ b/src/components/Pages/Guide/GuideSectionWrapper.js
@@ -19,13 +19,8 @@ function GuideSectionWrapper(props) {
 
   // updateSectionLocation if the window resized or Mobile status changed
   useEffect(()=>{
-    // 🔥 This is called in index.js
     updateSectionLocation(node.current.offsetTop, anchorTag);
   }, [isMobileOrTablet, resizeCount])
-
-  if ("#"+anchorTag === window.location.hash) {
-    console.log('the tag to anchor',anchorTag)
-  }
 
   return (
     <div

--- a/src/components/Pages/Guide/GuideSectionWrapper.js
+++ b/src/components/Pages/Guide/GuideSectionWrapper.js
@@ -19,8 +19,13 @@ function GuideSectionWrapper(props) {
 
   // updateSectionLocation if the window resized or Mobile status changed
   useEffect(()=>{
+    // 🔥 This is called in index.js
     updateSectionLocation(node.current.offsetTop, anchorTag);
   }, [isMobileOrTablet, resizeCount])
+
+  if ("#"+anchorTag === window.location.hash) {
+    console.log('the tag to anchor',anchorTag)
+  }
 
   return (
     <div

--- a/src/components/Recollect/index.js
+++ b/src/components/Recollect/index.js
@@ -17,14 +17,9 @@ class Recollect extends Component {
       options,
     );
     let loader = new window.Recollect.Widget.Loader(widgetOptions);
-
-    // window.requestAnimationFrame(function(){
-      console.log('\n\nONLOAD: go to', window.location.hash.split('#')[1])
-      const scrollToId = window.location.hash.split('#')[1]
-      document.getElementById(scrollToId).scrollIntoView(true);
-
-    // })
-    loader.load(); // 🔥move inside requestAnimationFrame
+    const scrollToId = window.location.hash.split('#')[1]
+    document.getElementById(scrollToId).scrollIntoView(true);
+    loader.load();
   }
 
   shouldComponentUpdate() {

--- a/src/components/Recollect/index.js
+++ b/src/components/Recollect/index.js
@@ -17,7 +17,7 @@ class Recollect extends Component {
       options,
     );
     let loader = new window.Recollect.Widget.Loader(widgetOptions);
-    const scrollToId = window.location.hash.split('#')[1]
+    const scrollToId = window.location.hash.split('#')[1];
     document.getElementById(scrollToId).scrollIntoView(true);
     loader.load();
   }

--- a/src/components/Recollect/index.js
+++ b/src/components/Recollect/index.js
@@ -17,7 +17,14 @@ class Recollect extends Component {
       options,
     );
     let loader = new window.Recollect.Widget.Loader(widgetOptions);
-    loader.load();
+
+    // window.requestAnimationFrame(function(){
+      console.log('\n\nONLOAD: go to', window.location.hash.split('#')[1])
+      const scrollToId = window.location.hash.split('#')[1]
+      document.getElementById(scrollToId).scrollIntoView(true);
+
+    // })
+    loader.load(); // 🔥move inside requestAnimationFrame
   }
 
   shouldComponentUpdate() {

--- a/src/css/base/_base.scss
+++ b/src/css/base/_base.scss
@@ -44,5 +44,3 @@ main {
 footer {
   z-index: 0;
 }
-
-


### PR DESCRIPTION
This is PR will fix that silly "stutter-step" of the scroll effect in our guide pages. Also, it makes sure to scroll to the location if a link to a specific point it followed.

This believe the behavior was being caused by the life-cycle of the url-change-to-react-rendering. 
- When the url is changed, either manually, or with javascript (as we do in this case). the browser "Looks" for the specific `id` right away. HOWEVER, react is saying. no no no, we're gonna rebuild this, AFTER, the fact. That's why I think it jumps. it starts to scroll to the point, but react renders in the middle of the process. 
- I honestly don't know if that is the complete case. But... using `   document.getElementById(anchorTag).scrollIntoView(true);` allows "US" to target the scoll location to our own beat, rather than the build in browser doing it... out of beat. 
- *Check it out! test it! Break it! * 

Fixes this Issue: https://app.zenhub.com/workspaces/techstack-5a78b88e1ce69f3510b678ef/issues/cityofaustin/techstack/3065

Deployed: https://deploy-preview-560--janis.netlify.com/

Before...
![Oct-11-2019 13-39-53](https://user-images.githubusercontent.com/15821138/66677702-d86ab280-ec2f-11e9-986f-a08303dccf0f.gif)
-
After...
![Oct-11-2019 13-41-18](https://user-images.githubusercontent.com/15821138/66677712-def92a00-ec2f-11e9-8003-6d9181952171.gif)
-
![url](https://user-images.githubusercontent.com/15821138/66677720-e4ef0b00-ec2f-11e9-9bc9-5f9ce439e53b.gif)
