### PR TITLE
3148 set max width 100%

### DIFF
--- a/scripts/build-joplin-cloud.sh
+++ b/scripts/build-joplin-cloud.sh
@@ -5,7 +5,7 @@ export CMS_API='https://joplin.herokuapp.com/api/graphql'
 export CMS_MEDIA='https://joplin-austin-gov.s3.amazonaws.com/media'
 export CMS_DOCS='multiple'
 
-if [ "$HEAD" == '3148-guide-image' ]; then
+if [ "$HEAD" == 'image-width-fix' ]; then
   export CMS_API='https://joplin-staging.herokuapp.com/api/graphql'
 fi
 

--- a/src/components/Pages/Guide/_Guide.scss
+++ b/src/components/Pages/Guide/_Guide.scss
@@ -59,7 +59,7 @@ $max-guide-tablet-width: $coa-medium-screen;
 }
 
 .coa-GuidePage__guide-page-placeholder {
-  max-width: 1160px;
+  // max-width: 1160px;
   display: block;
   margin: 0 auto;
 }

--- a/src/components/Pages/Guide/_Guide.scss
+++ b/src/components/Pages/Guide/_Guide.scss
@@ -59,7 +59,6 @@ $max-guide-tablet-width: $coa-medium-screen;
 }
 
 .coa-GuidePage__guide-page-placeholder {
-  // max-width: 1160px;
   display: block;
   margin: 0 auto;
 }


### PR DESCRIPTION
# Description

This fix allows the placeholder image to fill the remaining white space on guide pages.

* [Issue Link](https://app.zenhub.com/workspaces/techstack-5a78b88e1ce69f3510b678ef/issues/cityofaustin/techstack/3148)
