### PR TITLE
3184 - H1 font weight

### DIFF
--- a/src/components/Pages/Guide/_Guide.scss
+++ b/src/components/Pages/Guide/_Guide.scss
@@ -176,6 +176,7 @@ $max-guide-tablet-width: $coa-medium-screen;
 .coa-GuideSection__header {
   background: #ecf1f7;
   text-align: center;
+  font-weight: 500;
 
   padding-top: 2rem;
   padding-bottom: 2rem;
@@ -195,6 +196,10 @@ $max-guide-tablet-width: $coa-medium-screen;
   > p:last-child {
     // Let parent handle padding-bottom for the last nested paragraph
     margin-bottom: 0px;
+  }
+
+  h1 {
+    font-weight: 500;
   }
 }
 

--- a/src/css/base/_mixins.scss
+++ b/src/css/base/_mixins.scss
@@ -22,7 +22,6 @@
 //headings
 @mixin heading1() {
   font-size: $coa-font-size-medium;
-  font-weight: $coa-font-medium;
   line-height: $coa-line-height-medium;
   // margin-bottom: $coa-spacing-medium; Removing the bottom margin here centers the h1 on service pages
   // margin-top: $coa-spacing-medium;


### PR DESCRIPTION
# Description

All H1s should have a weight of 700. Except for Guide H1s, those are 500. 

I took out a line from the `_mixins.scss` that was overriding the H1 font weight. `_overwrites_uswds.scsc` has some conflicting rules set up. 

Fixes # 3184

* [Issue Link](https://github.com/cityofaustin/techstack/issues/3184)
* [Joplin Related Pull Request Link]- NA

# Testing Notes

Inspect H1s and confirm that they are 700 weight. Look at this guide (/en/health-safety/healthcare-prevention/disease-prevention/mobile-food-vendor-permit-guide) to see the guide H1s. 

* [Deployed Link](https://janis-3184-h1-font-weight.netlify.com/)

# Checklist:
- [x] Request reviewers
- [x] Slack-out message for review
- [ ] Link this PR in the issue
- [x] Moved card to *review* in zenhub