### PR TITLE
3186 - steps are ordered lists

### DIFF
--- a/src/components/Steps/_Steps.scss
+++ b/src/components/Steps/_Steps.scss
@@ -20,7 +20,7 @@
 }
 
 .coa-Steps__list {
-  & > ul {
+  & > ol {
     counter-reset: step-item;
     margin-bottom: $coa-space-level4;
     list-style-type: none;

--- a/src/components/Steps/index.js
+++ b/src/components/Steps/index.js
@@ -34,7 +34,7 @@ const Steps = ({ steps }) => (
       <Fragment>{mapSteps(steps, true)}</Fragment>
     ) : (
       <div className="coa-Steps__list">
-        <ul>{mapSteps(steps)}</ul>
+        <ol>{mapSteps(steps)}</ol>
       </div>
     )}
   </div>


### PR DESCRIPTION
# Description

> Steps are ordered lists, and they should appear that way to a screenreader—but currently they aren't doing that.

now they are! Changed the steps to be `ol` instead of `ul`, and updated the css.

Fixes # 3186

* [Issue Link](https://github.com/cityofaustin/techstack/issues/3186)
* [Joplin Related Pull Request Link]()

# Testing Notes

Inspect the element here for example: https://janis-3186-steps-are-ol.netlify.com/en/health-safety/health-records-certificates-2/birth-death-certificates/birth-and-death-certificates-test. The list is an `ol`


* [Deployed Link]( https://janis-3186-steps-are-ol.netlify.com//
# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub