### PR TITLE
3163 guide pages in español

### DIFF
--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -31,6 +31,9 @@ const branchOverrides = {
   "3202-form": {
     CMS_API: "https://joplin-pr-3202-form.herokuapp.com/api/graphql"
   },
+  '3163-guide-espanol': {
+    CMS_API: 'https://joplin-pr-3163-guide-pages.herokuapp.com/api/graphql'
+  }
 };
 
 module.exports = {

--- a/src/components/Pages/Guide/GuideContactInformation.js
+++ b/src/components/Pages/Guide/GuideContactInformation.js
@@ -1,7 +1,9 @@
 import React from 'react';
+import { injectIntl } from 'react-intl';
 
 import Phones from 'components/Contact/Phones';
 import Email from 'components/Contact/Email';
+import { misc as i18n1 } from 'js/i18n/definitions';
 
 const GuideContactInformation = ({
   contact: {
@@ -9,10 +11,11 @@ const GuideContactInformation = ({
     phoneNumber,
     email
   },
+  intl,
 }) => {
   return (
     <div className="coa-GuideSection__collection">
-      <h1 className="coa-GuideSection__header">Contact information</h1>
+      <h1 className="coa-GuideSection__header">{intl.formatMessage(i18n1.contactInformation)}</h1>
       <div className="row coa-GuideSection__container">
         {name && (
           <div className="col-xs-12 col-md-6 coa-GuidePage__contact-block coa-GuidePage__contact-name">
@@ -36,4 +39,4 @@ const GuideContactInformation = ({
   );
 };
 
-export default GuideContactInformation;
+export default injectIntl(GuideContactInformation);

--- a/src/components/Pages/Guide/GuideMenu.js
+++ b/src/components/Pages/Guide/GuideMenu.js
@@ -1,8 +1,10 @@
 import React, { Component } from 'react';
+import { injectIntl } from 'react-intl';
 
 import classNames from 'classnames';
 import { hyphenate } from './helpers';
 import { isMobileOrTablet } from 'js/helpers/reactMediaQueries';
+import { misc as i18n1 } from 'js/i18n/definitions';
 
 function GuideMenuLink({ title, anchorTag, isHeading, isCurrentSection }) {
   // Each GuideSectionWrapper has an id={this.props.anchorTag}
@@ -65,13 +67,13 @@ function GuideMenuSection({ section, currentSection }) {
   );
 }
 
-function GuideMenu({ contact, sections, currentSection }) {
+function GuideMenu({ contact, sections, currentSection, intl }) {
   return (
     <div>
       <div className="coa-GuideMenu__section">
         {contact && (
           <GuideMenuLink
-            title="Contact information"
+            title={intl.formatMessage(i18n1.contactInformation)}
             anchorTag="Contact-information"
             isHeading={true}
             isCurrentSection={currentSection === 'Contact-information'}
@@ -89,4 +91,4 @@ function GuideMenu({ contact, sections, currentSection }) {
   );
 }
 
-export default GuideMenu;
+export default injectIntl(GuideMenu);

--- a/src/js/i18n/definitions.js
+++ b/src/js/i18n/definitions.js
@@ -90,6 +90,7 @@ export const misc = defineMessages({
   or404: ', or ',
   contactUs404: 'contact us',
   privacyPolicy: 'Privacy policy',
+  contactInformation: 'Contact information'
 });
 
 export const navigation = defineMessages({

--- a/src/js/i18n/locales/es.json
+++ b/src/js/i18n/locales/es.json
@@ -62,6 +62,7 @@
   "misc.homeLink404": "página inicial",
   "misc.or404": ", o ",
   "misc.contactUs404": "contáctenos",
+  "misc.contactInformation": "Información de contacto",
   "navigation.home": "Inicio",
   "navigation.menu": "Menú",
   "navigation.openInNewWindow": "",


### PR DESCRIPTION
# Description

When in español, Janis-hardcoded Contact information section header should read Información de contacto

Fixes # 3163

* [Issue Link](https://app.zenhub.com/workspaces/techstack-5a78b88e1ce69f3510b678ef/issues/cityofaustin/techstack/3163)
* [Joplin Related Pull Request Link](https://github.com/cityofaustin/joplin/pull/445)

# Testing Notes

Go to https://janis-3163-guide-espanol.netlify.com/es/health-safety/healthcare-prevention/disease-prevention/food-trucks/ and switch to Spanish. Check that the heading **Contact Information** translates to **Información de contacto**

* [Deployed Link]()

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub