### PR TITLE
3230 - contact hours

### DIFF
--- a/src/components/Contact/Hours.js
+++ b/src/components/Contact/Hours.js
@@ -2,11 +2,9 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl, FormattedTime } from 'react-intl';
 import { findIndex, capitalize } from 'lodash';
-import moment from 'moment-timezone';
 
 import { WEEKDAY_MAP } from 'js/helpers/constants';
 import { date as i18n1, contact as i18n2 } from 'js/i18n/definitions';
-
 
 import { hoursPropTypes } from './proptypes';
 
@@ -22,18 +20,6 @@ class Hours extends Component {
       numeric: WEEKDAY_MAP[key],
     }));
     return weekday_collection.splice(day).concat(weekday_collection);
-  }
-
-  formatTime(time) {
-    let style;
-    // Only include minutes in display if there are minutes
-    if (moment(time).minutes()) {
-      style = "h:mma";
-    } else {
-      style = "ha";
-    }
-    
-    return moment.utc(time).format(style);
   }
 
   render() {
@@ -55,17 +41,16 @@ class Hours extends Component {
                 dayOfWeekNumeric: weekday.numeric,
               });
               return (
-                <tr key={weekday.name} >
+                <tr key={weekday.name}>
                   <th scope="row">
                     {intl.formatMessage(
                       i18n1['weekday' + capitalize(weekday.name)],
                     )}
                   </th>
-
                   {hourIndex > -1 && (
-                    <td>
-                      {`${this.formatTime(hours[hourIndex].startTime)}-${this.formatTime(hours[hourIndex].endTime)}`}
-                    </td>
+                    <td>{`${hours[hourIndex].startTime}-${
+                      hours[hourIndex].endTime
+                    }`}</td>
                   )}
                   {hourIndex === -1 && (
                     <td>{intl.formatMessage(i18n2.closed)}</td>

--- a/src/js/helpers/cleanData.js
+++ b/src/js/helpers/cleanData.js
@@ -1,6 +1,7 @@
 import { findKey } from 'lodash';
 import filesize from 'filesize';
 import axios from 'axios';
+import moment from 'moment-timezone';
 
 import { WEEKDAY_MAP } from 'js/helpers/constants';
 
@@ -11,12 +12,15 @@ export const cleanContacts = contacts => {
 
   const getWeekday = day => WEEKDAY_MAP[day.toUpperCase()];
 
-  const getTimestamp = hours => {
-    const splitHours = hours.split(':');
-    let timestamp = new Date(dateSeed);
-    timestamp.setHours(splitHours[0]);
-    timestamp.setMinutes(splitHours[1]);
-    return timestamp.getTime();
+  const formatTime = time => {
+    // Simplify time parsing. Times work on previews,
+    // but we don't do anything with timezones.
+    const momentTime = moment(time, 'HH:mm:ss');
+
+    // Only include minutes in display if there are minutes
+    const style = momentTime.minutes() ? 'h:mma' : 'ha';
+
+    return momentTime.format(style);
   };
 
   return contacts.edges.map(({ node: contact }) => {
@@ -35,8 +39,8 @@ export const cleanContacts = contacts => {
       cleaned.hours = cleaned.hours.edges.map(({ node: hours }) => ({
         dayOfWeek: hours.dayOfWeek.toLowerCase(),
         dayOfWeekNumeric: getWeekday(hours.dayOfWeek),
-        startTime: getTimestamp(hours.startTime),
-        endTime: getTimestamp(hours.endTime),
+        startTime: formatTime(hours.startTime),
+        endTime: formatTime(hours.endTime),
       }));
     }
     return cleaned;


### PR DESCRIPTION
# Description

Updates our contact formatting logic to ignore timezones

Fixes # (https://github.com/cityofaustin/techstack/issues/3230)

* [Issue Link](https://github.com/cityofaustin/techstack/issues/3230)

# Testing Notes

See that [preview](https://janis-3230-contact-hours.netlify.com/en/preview/information/UGFnZVJldmlzaW9uTm9kZToyMTQ0?CMS_API=https://joplin-pr-brians-janis-testing.herokuapp.com/api/graphql) and [live](https://janis-3230-contact-hours.netlify.com/en/police-oversight/how-we-store-and-use-your-data/) contact hours look the same.

# Checklist:
- [x] Request reviewers
- [ ] Slack-out message for review
- [x] Link this PR in the issue
- [x] Moved card to *review* in zenhub