### PR TITLE
3094 Guide page TOC

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react-static": "^7.2.2",
     "react-static-plugin-react-router": "^7.2.2",
     "react-universal-component": "^2.8.1",
+    "scroll-into-view": "^1.12.2",
     "stickyfilljs": "^2.1.0",
     "storybook": "^1.0.0",
     "ua-parser-js": "^0.7.17",

--- a/src/components/Pages/Guide/GuideMenu.js
+++ b/src/components/Pages/Guide/GuideMenu.js
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import { hyphenate } from './helpers';
 import { isMobileOrTablet } from 'js/helpers/reactMediaQueries';
 import { misc as i18n1 } from 'js/i18n/definitions';
+import scrollIntoView from 'scroll-into-view';
 
 const GuideMenuLink = ({
   title,
@@ -84,14 +85,33 @@ const GuideMenu = ({
   const goToSection = (e, anchorTag) => {
     setClickedSection(anchorTag);
     history.pushState(null, null, `#${anchorTag}`);
+    // scrollIntoView(document.getElementById(anchorTag));
+    // scrollIntoView(document.getElementById(anchorTag), { cancellable: false });
     document.getElementById(anchorTag).scrollIntoView(true);
   };
 
   useEffect(() => {
-    // debugger;
-    if (usingUrlAnchor) {
+    // If we're loading in an anchor url, we treat it as if we
+    // clicked on it, then let the rest of changes happen
+    // if we've already set a clickedSection, we shouldn't set it again
+    if (usingUrlAnchor && !clickedSection) {
+      // debugger;
       setClickedSection(currentSection);
-      doneWithAnchor();
+      scrollIntoView(
+        document.getElementById(`menu-${currentSection}`),
+        function(type) {
+          // Scrolling done.
+          // type will be 'complete' if the scroll completed or 'canceled' if the current scroll was canceled by a new scroll
+          scrollIntoView(document.getElementById(currentSection), function(
+            type,
+          ) {
+            // debugger;
+            doneWithAnchor();
+            // return;
+          });
+        },
+      );
+      return;
     }
 
     const el = document.getElementById(`menu-${currentSection}`);
@@ -106,6 +126,7 @@ const GuideMenu = ({
         }
       } else {
         el.scrollIntoView(true);
+        // scrollIntoView(el);
       }
     }
   }, [currentSection]);

--- a/src/components/Pages/Guide/GuideMenu.js
+++ b/src/components/Pages/Guide/GuideMenu.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, useEffect } from 'react';
 
 import classNames from 'classnames';
 import { hyphenate } from './helpers';
@@ -16,6 +16,7 @@ function GuideMenuLink({ title, anchorTag, isHeading, isCurrentSection }) {
       className={classNames('coa-GuideMenu__link-wrapper', {
         'coa-GuideMenu__current-section': isCurrentSection,
       })}
+      id={`menu-${anchorTag}`}
     >
       <div
         className={classNames('coa-GuideMenu__link', {
@@ -66,6 +67,13 @@ function GuideMenuSection({ section, currentSection }) {
 }
 
 function GuideMenu({ contact, sections, currentSection }) {
+  useEffect(() => {
+    const el = document.getElementById(`menu-${currentSection}`);
+    if (el) {
+      el.scrollIntoView();
+    }
+  });
+
   return (
     <div>
       <div className="coa-GuideMenu__section">

--- a/src/components/Pages/Guide/GuideMenu.js
+++ b/src/components/Pages/Guide/GuideMenu.js
@@ -1,4 +1,4 @@
-import React, { Component, useEffect } from 'react';
+import React, { Component, useEffect, useState } from 'react';
 import { injectIntl } from 'react-intl';
 
 import classNames from 'classnames';
@@ -6,13 +6,13 @@ import { hyphenate } from './helpers';
 import { isMobileOrTablet } from 'js/helpers/reactMediaQueries';
 import { misc as i18n1 } from 'js/i18n/definitions';
 
-function GuideMenuLink({ title, anchorTag, isHeading, isCurrentSection }) {
-  // Each GuideSectionWrapper has an id={this.props.anchorTag}
-  function goToSection(e) {
-    history.pushState(null, null, `#${anchorTag}`);
-    document.getElementById(anchorTag).scrollIntoView(true);
-  }
-
+const GuideMenuLink = ({
+  title,
+  anchorTag,
+  isHeading,
+  isCurrentSection,
+  goToSection,
+}) => {
   return (
     <div
       className={classNames('coa-GuideMenu__link-wrapper', {
@@ -26,15 +26,15 @@ function GuideMenuLink({ title, anchorTag, isHeading, isCurrentSection }) {
           'coa-GuideMenu__subheading': !isHeading,
           'coa-GuideMenu__current-section': isCurrentSection,
         })}
-        onClick={goToSection}
+        onClick={e => goToSection(e, anchorTag)}
       >
         <span className="coa-GuideMenu__title-text">{title}</span>
       </div>
     </div>
   );
-}
+};
 
-function GuideMenuSection({ section, currentSection }) {
+function GuideMenuSection({ section, currentSection, goToSection }) {
   const headingAnchorTag = hyphenate(section.heading);
   const subHeadings = section.pages.map((page, index) => {
     const title =
@@ -54,6 +54,7 @@ function GuideMenuSection({ section, currentSection }) {
         anchorTag={headingAnchorTag}
         isHeading={true}
         isCurrentSection={currentSection === headingAnchorTag}
+        goToSection={goToSection}
       />
       {subHeadings.map((subHeading, index) => (
         <GuideMenuLink
@@ -62,19 +63,39 @@ function GuideMenuSection({ section, currentSection }) {
           anchorTag={subHeading.anchorTag}
           isHeading={false}
           isCurrentSection={currentSection === subHeading.anchorTag}
+          goToSection={goToSection}
         />
       ))}
     </div>
   );
 }
 
-function GuideMenu({ contact, sections, currentSection, intl }) {
+const GuideMenu = ({ contact, sections, currentSection, intl }) => {
+  const [clickedSection, setClickedSection] = useState(null);
+
+  // Each GuideSectionWrapper has an id={this.props.anchorTag}
+  const goToSection = (e, anchorTag) => {
+    setClickedSection(anchorTag);
+    history.pushState(null, null, `#${anchorTag}`);
+    document.getElementById(anchorTag).scrollIntoView(true);
+  };
+
   useEffect(() => {
     const el = document.getElementById(`menu-${currentSection}`);
     if (el) {
-      el.scrollIntoView();
+      if (clickedSection) {
+        // If we clicked a section, we don't want to mess around with this logic
+        // until we hit that section. This fires every time we scroll to a new
+        // section, and is fired a bunch when the click fires off a scroll
+        if (currentSection === clickedSection) {
+          // We made it! back to business as usual
+          setClickedSection(null);
+        }
+      } else {
+        el.scrollIntoView();
+      }
     }
-  });
+  }, [currentSection]);
 
   return (
     <div>
@@ -85,6 +106,7 @@ function GuideMenu({ contact, sections, currentSection, intl }) {
             anchorTag="Contact-information"
             isHeading={true}
             isCurrentSection={currentSection === 'Contact-information'}
+            goToSection={goToSection}
           />
         )}
       </div>
@@ -93,10 +115,11 @@ function GuideMenu({ contact, sections, currentSection, intl }) {
           key={index}
           section={section}
           currentSection={currentSection}
+          goToSection={goToSection}
         />
       ))}
     </div>
   );
-}
+};
 
 export default injectIntl(GuideMenu);

--- a/src/components/Pages/Guide/GuideMenu.js
+++ b/src/components/Pages/Guide/GuideMenu.js
@@ -70,7 +70,14 @@ function GuideMenuSection({ section, currentSection, goToSection }) {
   );
 }
 
-const GuideMenu = ({ contact, sections, currentSection, intl }) => {
+const GuideMenu = ({
+  contact,
+  sections,
+  currentSection,
+  usingUrlAnchor,
+  doneWithAnchor,
+  intl,
+}) => {
   const [clickedSection, setClickedSection] = useState(null);
 
   // Each GuideSectionWrapper has an id={this.props.anchorTag}
@@ -81,6 +88,12 @@ const GuideMenu = ({ contact, sections, currentSection, intl }) => {
   };
 
   useEffect(() => {
+    // debugger;
+    if (usingUrlAnchor) {
+      setClickedSection(currentSection);
+      doneWithAnchor();
+    }
+
     const el = document.getElementById(`menu-${currentSection}`);
     if (el) {
       if (clickedSection) {
@@ -92,7 +105,7 @@ const GuideMenu = ({ contact, sections, currentSection, intl }) => {
           setClickedSection(null);
         }
       } else {
-        el.scrollIntoView();
+        el.scrollIntoView(true);
       }
     }
   }, [currentSection]);

--- a/src/components/Pages/Guide/index.js
+++ b/src/components/Pages/Guide/index.js
@@ -22,6 +22,7 @@ import guidePagePlaceholder from 'images/guide_page_placeholder.png';
 
 function Guide(props) {
   const [currentSection, setCurrentSection] = useState(null);
+  const [usingUrlAnchor, setUsingUrlAnchor] = useState(false);
   const [resizeCount, setResizeCount] = useState(0);
   const [sectionLocations, dispatchSectionLocations] = useReducer(
     (sectionLocations, { action, payload }) => {
@@ -119,6 +120,11 @@ function Guide(props) {
     };
   }, [resizeCount]);
 
+  // passing things from useState doesn't work so we need to wrap this
+  function doneWithAnchor() {
+    setUsingUrlAnchor(false);
+  }
+
   // Organize variables that will be used in rendering
   let {
     id,
@@ -137,6 +143,20 @@ function Guide(props) {
     contextualNavData,
   } = props.guidePage;
   let { intl } = props;
+
+  // if we don't already have a current section set
+  // try getting the anchor from the url
+  // so we can pass it into the menu
+  // debugger;
+  if (
+    !currentSection &&
+    document &&
+    document.location &&
+    document.location.hash
+  ) {
+    setCurrentSection(document.location.hash.substring(1));
+    setUsingUrlAnchor(true);
+  }
 
   return (
     <div ref={node}>
@@ -185,6 +205,8 @@ function Guide(props) {
                   contact={contact}
                   sections={sections}
                   currentSection={currentSection}
+                  usingUrlAnchor={usingUrlAnchor}
+                  doneWithAnchor={doneWithAnchor}
                 />
               </div>
             )}

--- a/src/components/Pages/Guide/index.js
+++ b/src/components/Pages/Guide/index.js
@@ -22,6 +22,7 @@ import guidePagePlaceholder from 'images/guide_page_placeholder.png';
 
 function Guide(props) {
   const [currentSection, setCurrentSection] = useState(null);
+  const [urlAnchorFuse, setUrlAnchorFuse] = useState(false);
   const [usingUrlAnchor, setUsingUrlAnchor] = useState(false);
   const [resizeCount, setResizeCount] = useState(0);
   const [sectionLocations, dispatchSectionLocations] = useReducer(
@@ -123,6 +124,7 @@ function Guide(props) {
   // passing things from useState doesn't work so we need to wrap this
   function doneWithAnchor() {
     setUsingUrlAnchor(false);
+    setUrlAnchorFuse(true);
   }
 
   // Organize variables that will be used in rendering
@@ -150,6 +152,7 @@ function Guide(props) {
   // debugger;
   if (
     !currentSection &&
+    !urlAnchorFuse &&
     document &&
     document.location &&
     document.location.hash

--- a/yarn.lock
+++ b/yarn.lock
@@ -13052,6 +13052,11 @@ scriptjs@^2.5.9:
   resolved "https://registry.yarnpkg.com/scriptjs/-/scriptjs-2.5.9.tgz#343915cd2ec2ed9bfdde2b9875cd28f59394b35f"
   integrity sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg==
 
+scroll-into-view@^1.12.2:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/scroll-into-view/-/scroll-into-view-1.12.2.tgz#23207834ac32c914cd259f18c758fa3ad8222fb1"
+  integrity sha512-bRfeapQ5YQPNCqH1b2qXTRTOvVabkbp/YUpd/Ud54XurKKns+Qg53r5VL1vnEe1xEPlvqCj6gtXrnHXWNxBJ4Q==
+
 scss-tokenizer@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz#8eb06db9a9723333824d3f5530641149847ce5d1"


### PR DESCRIPTION
# Description

When the guide page was too tall for the window, the (menu) current section was getting selected below the screen sometimes. This makes it so the current section is scrolled into view in the menu

Fixes #  https://github.com/cityofaustin/techstack/issues/3094

# Testing Notes

Try scrolling around on a guide

* [Deployed Link]()

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub