### PR TITLE
3205 - only hide scrollbar for guide TOC, show all others

### DIFF
--- a/src/components/Pages/Guide/_Guide.scss
+++ b/src/components/Pages/Guide/_Guide.scss
@@ -80,13 +80,17 @@ $max-guide-tablet-width: $coa-medium-screen;
   margin-top: $sticky-guide-top;
   top: 0px;
 
-  // Hide the nav scrollbar in Chrome/Safari
+  // Hide TOC scrollbar in:
+  // Webkit eg. Chrome/Safari
   &::-webkit-scrollbar {
     width: 0 !important;
   }
 
-  // Hide the nav scrollbar in edge/ie
+  // Edge/Internet Explorer
   -ms-overflow-style: none;
+
+  // Firefox
+  scrollbar-width: none;
 }
 
 .coa-GuidePage__main-content {

--- a/src/components/Pages/Guide/_Guide.scss
+++ b/src/components/Pages/Guide/_Guide.scss
@@ -79,6 +79,14 @@ $max-guide-tablet-width: $coa-medium-screen;
   overflow-y: scroll;
   margin-top: $sticky-guide-top;
   top: 0px;
+
+  // Hide the nav scrollbar in Chrome/Safari
+  &::-webkit-scrollbar {
+    width: 0 !important;
+  }
+
+  // Hide the nav scrollbar in edge/ie
+  -ms-overflow-style: none;
 }
 
 .coa-GuidePage__main-content {

--- a/src/css/base/_base.scss
+++ b/src/css/base/_base.scss
@@ -8,17 +8,9 @@ html {
   scroll-behavior: smooth;
 }
 
-// Hides the main scrollbar in chrome on windows 10
-::-webkit-scrollbar {
-  width: 0 !important;
-}
-
 body {
   font-size: $coa-font-size-small;
   line-height: $coa-line-height-small;
-
-  // This hides scrollbars in edge on windows 10
-  -ms-overflow-style: none;
 
   @include media($coa-medium-screen) {
     font-size: $coa-font-size-md-small;


### PR DESCRIPTION
# Description

make it so scrollbars show up everywhere EXCEPT the guide page TOC (instead of hiding them everywhere)

Fixes:

* Issue Link https://github.com/cityofaustin/techstack/issues/3205

# Testing Notes

make sure scrollbars show up in all sorts of different browsers.

* Deployed Link: https://janis-3205-scrollbars.netlify.com/en/health-safety/healthcare-prevention/disease-prevention/mobile-food-vendor-permit-guide

# Checklist:
- [x] Request reviewers
- [ ] Slack-out message for review
- [x] Link this PR in the issue
- [ ] Moved card to *review* in zenhub