### PR TITLE
3219 en dash contacts

### DIFF
--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -34,7 +34,7 @@ const branchOverrides = {
   "3202-form": {
     CMS_API: "https://joplin-pr-3202-form.herokuapp.com/api/graphql"
   },
-  '3163-guide-espanol': {
+  '3219-en-dash-contacts': {
     CMS_API: 'https://joplin-pr-3163-guide-pages.herokuapp.com/api/graphql'
   }
 };

--- a/src/components/Contact/ContactDetails.js
+++ b/src/components/Contact/ContactDetails.js
@@ -25,8 +25,8 @@ const ContactDetails = ({ contacts, intl }) => (
     <SectionHeader isSerif={true}>
       {intl.formatMessage(i18n.questionsTitle)}
     </SectionHeader>
-    {contacts.map(c => (
-      <ContactDetailsEntry contact={c} />
+    {contacts.map((c, index) => (
+      <ContactDetailsEntry contact={c} key={index} />
     ))}
   </div>
 );
@@ -55,7 +55,7 @@ ContactDetailsEntry.propTypes = {
     email: emailPropTypes,
     hours: hoursPropTypes,
     phoneNumber: phonePropTypes,
-  }).isRequired,
+  })
 };
 
 export default injectIntl(ContactDetails);

--- a/src/components/Contact/Hours.js
+++ b/src/components/Contact/Hours.js
@@ -49,7 +49,7 @@ class Hours extends Component {
                   </th>
                   {hourIndex > -1 && (
                     // \u2013 is unicode for the en dash –
-                    <td>{`${hours[hourIndex].startTime} \u2013 ${
+                    <td>{`${hours[hourIndex].startTime}\u2013${
                       hours[hourIndex].endTime
                     }`}</td>
                   )}

--- a/src/components/Contact/Hours.js
+++ b/src/components/Contact/Hours.js
@@ -48,7 +48,8 @@ class Hours extends Component {
                     )}
                   </th>
                   {hourIndex > -1 && (
-                    <td>{`${hours[hourIndex].startTime}-${
+                    // \u2013 is unicode for the en dash –
+                    <td>{`${hours[hourIndex].startTime} \u2013 ${
                       hours[hourIndex].endTime
                     }`}</td>
                   )}

--- a/src/components/Contact/proptypes.js
+++ b/src/components/Contact/proptypes.js
@@ -14,12 +14,12 @@ export const hoursPropTypes = PropTypes.arrayOf(
   PropTypes.shape({
     dayOfWeek: PropTypes.string.isRequired,
     dayOfWeekNumeric: PropTypes.number.isRequired,
-    endTime: PropTypes.number.isRequired,
-    startTime: PropTypes.number.isRequired,
+    endTime: PropTypes.string.isRequired,
+    startTime: PropTypes.string.isRequired,
   }),
 ).isRequired;
 
 export const phonePropTypes = PropTypes.shape({
-  default: PropTypes.string.isRequired,
-  tty: PropTypes.string.isRequired,
+  phoneDescription: PropTypes.string.isRequired, // is this required?
+  phoneNumber: PropTypes.string.isRequired,
 }).isRequired;

--- a/src/js/helpers/cleanData.js
+++ b/src/js/helpers/cleanData.js
@@ -13,12 +13,15 @@ export const cleanContacts = contacts => {
   const getWeekday = day => WEEKDAY_MAP[day.toUpperCase()];
 
   const formatTime = time => {
+    if (time==='12:00:00'){
+      return 'Noon';
+    }
     // Simplify time parsing. Times work on previews,
     // but we don't do anything with timezones.
     const momentTime = moment(time, 'HH:mm:ss');
 
     // Only include minutes in display if there are minutes
-    const style = momentTime.minutes() ? 'h:mma' : 'ha';
+    const style = momentTime.minutes() ? 'h:mm a' : 'h a';
 
     return momentTime.format(style);
   };


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

I changed the hyphen in the hours to an en dash "–" instead of the hyphen it had "-"

I updated spacing so that "5 am–3 pm", space between the time and the pm/am but no space to the en dash. 

*also* the style guide says to use Noon instead of 12 pm. I could not find in the moment docs an automatic format to add so instead if the time is '12:00:00' return 'Noon'. 

I also updated some proptypes and added a key to get rid of react warnings that were popping up.

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?

Go here https://janis-3219-en-dash-contacts.netlify.com/en/police-oversight/: to see the hours listed. The dash is a en dash instead of a hyphen. En dashes are slightly longer than hyphens but shorter than em dashes. You can highlight the punctuation and google search it to confirm its an en dash. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
