### PR TITLE
Issue 3288: Embedded form styling

### DIFF
--- a/src/components/Pages/Form.js
+++ b/src/components/Pages/Form.js
@@ -55,14 +55,16 @@ function FormPage({
         </PageHeader>
         <div className="coa-Page__all-of-the-content">
           <div className="coa-Page__main-content">
-            {formUrl && (
-              <IframeResizer
-                forwardRef={iframeRef}
-                src={formUrl}
-                className="coa-FormPage__IframeResizer-default"
-                frameBorder="0"
-              />
-            )}
+            <div className="coa-FormPage__iframe-container">
+              {formUrl && (
+                <IframeResizer
+                  forwardRef={iframeRef}
+                  src={formUrl}
+                  className="coa-FormPage__IframeResizer-default"
+                  frameBorder="0"
+                />
+              )}
+            </div>
           </div>
           <div className="coa-Page__side-content">
             <div className="coa-ServicePage__contacts-desktop">

--- a/src/components/Pages/Form.js
+++ b/src/components/Pages/Form.js
@@ -29,7 +29,6 @@ function FormPage({
     toplink,
     description,
     formUrl,
-    contacts,
     coaGlobal,
     contextualNavData,
   },
@@ -63,13 +62,6 @@ function FormPage({
                   className="coa-FormPage__IframeResizer-default"
                   frameBorder="0"
                 />
-              )}
-            </div>
-          </div>
-          <div className="coa-Page__side-content">
-            <div className="coa-ServicePage__contacts-desktop">
-              {!!contacts && !!contacts.length && (
-                <ContactDetails contact={contacts[0]} />
               )}
             </div>
           </div>

--- a/src/components/Pages/_Form.scss
+++ b/src/components/Pages/_Form.scss
@@ -1,4 +1,9 @@
-// Recommended styling from the docs
+.coa-FormPage__iframe-container {
+  padding-left: 20rem;
+  padding-right: 20rem;
+}
+
+// Recommended styling from iframe-resizer docs
 .coa-FormPage__IframeResizer-default {
   width: 1px;
   min-width: 100%;

--- a/src/components/Pages/_Form.scss
+++ b/src/components/Pages/_Form.scss
@@ -1,6 +1,6 @@
 .coa-FormPage__iframe-container {
-  padding-left: 20rem;
-  padding-right: 20rem;
+  padding-left: 2rem;
+  padding-right: 2rem;
 }
 
 // Recommended styling from iframe-resizer docs


### PR DESCRIPTION
https://github.com/cityofaustin/techstack/issues/3288

# Description

Implemented all requested style fixes for embedded forms on Janis. Take a look and see if it looks right on all of our favorite breakpoints.

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

You might feel like seeing what changes I made in https://github.com/cityofaustin/formstack-alpha-theme

Recent updates:
- added scss compiling
- added a footer.hbs template for js that was required after the body was rendered.
- Fixed the padding for iframe embedded forms only
- used js to move helper text after the form loads

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
1. Test out a single page form here: https://janis-3288-content-padding.netlify.com/en/health-safety/health-records-certificates-2/birth-death-certificates/single-page-form-test
2. Test out a multi-page form here: https://janis-3288-content-padding.netlify.com/en/health-safety/health-records-certificates-2/birth-death-certificates/multi-page-form-test

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
