### PR TITLE
added ariaLabel prop to ExternalLink

### DIFF
--- a/src/components/ExternalLink/index.js
+++ b/src/components/ExternalLink/index.js
@@ -13,7 +13,7 @@ const ExternalLink = ({ to, noIcon, children, intl, ariaLabel }) => (
     className="coa-ExternalLink"
     target="_blank"
     rel="noopener noreferrer"
-    aria-label={(ariaLabel) ? ariaLabel + intl.formatMessage(navigation.openInNewWindow) : intl.formatMessage(navigation.openInNewWindow)}
+    aria-label={(ariaLabel) ? ariaLabel + {' '} + intl.formatMessage(navigation.openInNewWindow) : intl.formatMessage(navigation.openInNewWindow)}
   >
     {children}
     {!noIcon && <i className="material-icons coa-ExternalLinkMaterial">

--- a/src/components/ExternalLink/index.js
+++ b/src/components/ExternalLink/index.js
@@ -2,17 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 
-import { navigation as i18n } from 'js/i18n/definitions';
+import { navigation } from 'js/i18n/definitions';
 
 import ExternalLinkSVG from 'components/SVGs/ExternalLink';
 
-const ExternalLink = ({ to, noIcon, children, intl }) => (
+const ExternalLink = ({ to, noIcon, children, intl, ariaLabel }) => (
+// passing ariaLabel as a way to have an accessible name + behavior (opens in new window)
   <a
     href={to}
     className="coa-ExternalLink"
     target="_blank"
     rel="noopener noreferrer"
-    aria-label={intl.formatMessage(i18n.openInNewWindow)}
+    aria-label={(ariaLabel) ? ariaLabel + intl.formatMessage(navigation.openInNewWindow) : intl.formatMessage(navigation.openInNewWindow)}
   >
     {children}
     {!noIcon && <i className="material-icons coa-ExternalLinkMaterial">

--- a/src/components/ExternalLink/index.js
+++ b/src/components/ExternalLink/index.js
@@ -7,18 +7,22 @@ import { navigation } from 'js/i18n/definitions';
 import ExternalLinkSVG from 'components/SVGs/ExternalLink';
 
 const ExternalLink = ({ to, noIcon, children, intl, ariaLabel }) => (
-// passing ariaLabel as a way to have an accessible name + behavior (opens in new window)
+  // passing ariaLabel as a way to have an accessible name + behavior (opens in new window)
   <a
     href={to}
     className="coa-ExternalLink"
     target="_blank"
     rel="noopener noreferrer"
-    aria-label={(ariaLabel) ? ariaLabel + {' '} + intl.formatMessage(navigation.openInNewWindow) : intl.formatMessage(navigation.openInNewWindow)}
+    aria-label={
+      ariaLabel
+        ? ariaLabel + `, ` + intl.formatMessage(navigation.openInNewWindow)
+        : intl.formatMessage(navigation.openInNewWindow)
+    }
   >
     {children}
-    {!noIcon && <i className="material-icons coa-ExternalLinkMaterial">
-      open_in_new
-    </i>}
+    {!noIcon && (
+      <i className="material-icons coa-ExternalLinkMaterial">open_in_new</i>
+    )}
   </a>
 );
 

--- a/src/components/PageSections/Header/index.js
+++ b/src/components/PageSections/Header/index.js
@@ -200,11 +200,15 @@ class Header extends Component {
               </div>
               <div className="coa-Header__right-controls-wrapper">
                 <div className="coa-Header__right-controls">
-                  <ExternalLink to="http://www.austintexas.gov/airport">
+                  <ExternalLink to="http://www.austintexas.gov/airport"
+                    ariaLabel={intl.formatMessage(i18n1.airport)}
+                    >
                     {intl.formatMessage(i18n1.airport)}
                   </ExternalLink>
                   <span className="coa-text-spacer--vertical" />
-                  <ExternalLink to="http://311.austintexas.gov/">
+                  <ExternalLink to="http://311.austintexas.gov/"
+                    ariaLabel={"three one one"}
+                    >
                     311
                   </ExternalLink>
                 </div>


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description
This is kinda a short term//tech debt fix for this problem. Now that we're on React Static 7, we should probably refactor links to use Link component. But that is for another day. 
<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

Use a screen reader, Airport and 311 should read "Airport opens in new window" and "three one one opens in new window"

https://janis-3336-aria-label-external.netlify.com

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
