### PR TITLE
3094 guide toc 2

### DIFF
--- a/src/components/Pages/Guide/GuideMenu.js
+++ b/src/components/Pages/Guide/GuideMenu.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, useEffect } from 'react';
 
 import classNames from 'classnames';
 import { hyphenate } from './helpers';
@@ -16,6 +16,7 @@ function GuideMenuLink({ title, anchorTag, isHeading, isCurrentSection }) {
       className={classNames('coa-GuideMenu__link-wrapper', {
         'coa-GuideMenu__current-section': isCurrentSection,
       })}
+      id={`menu-${anchorTag}`}
     >
       <div
         className={classNames('coa-GuideMenu__link', {
@@ -66,6 +67,13 @@ function GuideMenuSection({ section, currentSection }) {
 }
 
 function GuideMenu({ contact, sections, currentSection }) {
+  useEffect(() => {
+    const el = document.getElementById(`menu-${currentSection}`);
+    if (el) {
+      el.scrollIntoView();
+    }
+  });
+
   return (
     <div>
       <div className="coa-GuideMenu__section">

--- a/src/components/Pages/Guide/GuideMenu.js
+++ b/src/components/Pages/Guide/GuideMenu.js
@@ -1,19 +1,13 @@
 import React, { Component, useEffect, useState } from 'react';
 import { injectIntl } from 'react-intl';
-import { useLocation } from 'react-router-dom';
+import { useLocation, Link } from 'react-router-dom';
 
 import classNames from 'classnames';
 import { hyphenate } from './helpers';
 import { isMobileOrTablet } from 'js/helpers/reactMediaQueries';
 import { misc as i18n1 } from 'js/i18n/definitions';
 
-const GuideMenuLink = ({
-  title,
-  anchorTag,
-  isHeading,
-  isCurrentSection,
-  goToSection,
-}) => {
+const GuideMenuLink = ({ title, anchorTag, isHeading, isCurrentSection }) => {
   return (
     <div
       className={classNames('coa-GuideMenu__link-wrapper', {
@@ -21,21 +15,21 @@ const GuideMenuLink = ({
       })}
       id={`menu-${anchorTag}`}
     >
-      <div
+      <Link
         className={classNames('coa-GuideMenu__link', {
           'coa-GuideMenu__heading': isHeading,
           'coa-GuideMenu__subheading': !isHeading,
           'coa-GuideMenu__current-section': isCurrentSection,
         })}
-        onClick={e => goToSection(e, anchorTag)}
+        to={`#${anchorTag}`}
       >
         <span className="coa-GuideMenu__title-text">{title}</span>
-      </div>
+      </Link>
     </div>
   );
 };
 
-function GuideMenuSection({ section, currentSection, goToSection }) {
+function GuideMenuSection({ section, currentSection }) {
   const headingAnchorTag = hyphenate(section.heading);
   const subHeadings = section.pages.map((page, index) => {
     const title =
@@ -55,7 +49,6 @@ function GuideMenuSection({ section, currentSection, goToSection }) {
         anchorTag={headingAnchorTag}
         isHeading={true}
         isCurrentSection={currentSection === headingAnchorTag}
-        goToSection={goToSection}
       />
       {subHeadings.map((subHeading, index) => (
         <GuideMenuLink
@@ -64,7 +57,6 @@ function GuideMenuSection({ section, currentSection, goToSection }) {
           anchorTag={subHeading.anchorTag}
           isHeading={false}
           isCurrentSection={currentSection === subHeading.anchorTag}
-          goToSection={goToSection}
         />
       ))}
     </div>
@@ -75,17 +67,18 @@ const GuideMenu = ({ contact, sections, currentSection, intl }) => {
   const [clickedSection, setClickedSection] = useState(null);
 
   // Each GuideSectionWrapper has an id={this.props.anchorTag}
-  const goToSection = (e, anchorTag) => {
-    setClickedSection(anchorTag);
-    history.pushState(null, null, `#${anchorTag}`);
-    document.getElementById(anchorTag).scrollIntoView(true);
-  };
+  // const goToSection = (e, anchorTag) => {
+  //   setClickedSection(anchorTag);
+  //   history.pushState(null, null, `#${anchorTag}`);
+  //   document.getElementById(anchorTag).scrollIntoView(true);
+  // };
 
   let location = useLocation();
   useEffect(() => {
     if (location && location.hash) {
       // debugger;
       setClickedSection(location.hash.substring(1));
+      document.getElementById(location.hash.substring(1)).scrollIntoView(true);
     }
     // const initialClick = 'Learn-and-prepare-4';
     // setClickedSection(initialClick);
@@ -118,7 +111,6 @@ const GuideMenu = ({ contact, sections, currentSection, intl }) => {
             anchorTag="Contact-information"
             isHeading={true}
             isCurrentSection={currentSection === 'Contact-information'}
-            goToSection={goToSection}
           />
         )}
       </div>
@@ -127,7 +119,6 @@ const GuideMenu = ({ contact, sections, currentSection, intl }) => {
           key={index}
           section={section}
           currentSection={currentSection}
-          goToSection={goToSection}
         />
       ))}
     </div>

--- a/src/components/Pages/Guide/GuideMenu.js
+++ b/src/components/Pages/Guide/GuideMenu.js
@@ -1,5 +1,6 @@
 import React, { Component, useEffect, useState } from 'react';
 import { injectIntl } from 'react-intl';
+import { useLocation } from 'react-router-dom';
 
 import classNames from 'classnames';
 import { hyphenate } from './helpers';
@@ -80,6 +81,16 @@ const GuideMenu = ({ contact, sections, currentSection, intl }) => {
     document.getElementById(anchorTag).scrollIntoView(true);
   };
 
+  let location = useLocation();
+  useEffect(() => {
+    if (location && location.hash) {
+      // debugger;
+      setClickedSection(location.hash.substring(1));
+    }
+    // const initialClick = 'Learn-and-prepare-4';
+    // setClickedSection(initialClick);
+  }, [location]);
+
   useEffect(() => {
     const el = document.getElementById(`menu-${currentSection}`);
     if (el) {
@@ -90,6 +101,7 @@ const GuideMenu = ({ contact, sections, currentSection, intl }) => {
         if (currentSection === clickedSection) {
           // We made it! back to business as usual
           setClickedSection(null);
+          el.scrollIntoView();
         }
       } else {
         el.scrollIntoView();

--- a/src/components/Pages/Guide/GuideMenu.js
+++ b/src/components/Pages/Guide/GuideMenu.js
@@ -1,6 +1,6 @@
 import React, { Component, useEffect, useState } from 'react';
 import { injectIntl } from 'react-intl';
-import { useLocation, Link } from 'react-router-dom';
+import { useLocation, useHistory, Link } from 'react-router-dom';
 
 import classNames from 'classnames';
 import { hyphenate } from './helpers';
@@ -79,34 +79,52 @@ const GuideMenu = ({ contact, sections, currentSection, intl }) => {
       // debugger;
       console.log(location.hash);
       setClickedSection(location.hash.substring(1));
-      document.getElementById(location.hash.substring(1)).scrollIntoView(true);
+
+      // setTimeout(() => {
+      document.getElementById(location.hash.substring(1)).scrollIntoView();
+      // }, 5000);
+
+      // const el = document.getElementById(`menu-${currentSection}`);
+      // if (el) {
+      //   // setTimeout(() => {
+      //   el.scrollIntoView(true);
+      //   // }, 5000);
+      // }
     }
     // const initialClick = 'Learn-and-prepare-4';
     // setClickedSection(initialClick);
   }, [location]);
 
+  let history = useHistory();
   useEffect(() => {
-    console.log(currentSection);
-    if (currentSection) {
-      history.pushState(null, null, `#${currentSection}`);
-    }
-
     // debugger;
-    // const el = document.getElementById(`menu-${currentSection}`);
-    // if (el) {
-    //   if (clickedSection) {
-    //     // If we clicked a section, we don't want to mess around with this logic
-    //     // until we hit that section. This fires every time we scroll to a new
-    //     // section, and is fired a bunch when the click fires off a scroll
-    //     if (currentSection === clickedSection) {
-    //       // We made it! back to business as usual
-    //       setClickedSection(null);
-    //       el.scrollIntoView(true);
-    //     }
-    //   } else {
-    //     el.scrollIntoView(true);
-    //   }
-    // }
+    const el = document.getElementById(`menu-${currentSection}`);
+    if (el) {
+      if (clickedSection) {
+        console.log(clickedSection);
+        // If we clicked a section, we don't want to mess around with this logic
+        // until we hit that section. This fires every time we scroll to a new
+        // section, and is fired a bunch when the click fires off a scroll
+        if (currentSection === clickedSection) {
+          // We made it! back to business as usual
+          // el.scrollIntoView(true);
+
+          setClickedSection(null);
+          // el.scrollIntoView(true);
+          // debugger;
+
+          // document.getElementById(currentSection).scrollIntoView(true);
+          return;
+        }
+      } else {
+        // console.log(currentSection);
+        el.scrollIntoView();
+        // debugger;
+        // if (currentSection) {
+        //   history.push(`#${currentSection}`);
+        // }
+      }
+    }
   }, [currentSection]);
 
   return (

--- a/src/components/Pages/Guide/GuideMenu.js
+++ b/src/components/Pages/Guide/GuideMenu.js
@@ -1,4 +1,4 @@
-import React, { Component, useEffect } from 'react';
+import React, { Component, useEffect, useState } from 'react';
 import { injectIntl } from 'react-intl';
 
 import classNames from 'classnames';
@@ -6,13 +6,13 @@ import { hyphenate } from './helpers';
 import { isMobileOrTablet } from 'js/helpers/reactMediaQueries';
 import { misc as i18n1 } from 'js/i18n/definitions';
 
-function GuideMenuLink({ title, anchorTag, isHeading, isCurrentSection }) {
-  // Each GuideSectionWrapper has an id={this.props.anchorTag}
-  function goToSection(e) {
-    history.pushState(null, null, `#${anchorTag}`);
-    document.getElementById(anchorTag).scrollIntoView(true);
-  }
-
+const GuideMenuLink = ({
+  title,
+  anchorTag,
+  isHeading,
+  isCurrentSection,
+  goToSection,
+}) => {
   return (
     <div
       className={classNames('coa-GuideMenu__link-wrapper', {
@@ -26,15 +26,15 @@ function GuideMenuLink({ title, anchorTag, isHeading, isCurrentSection }) {
           'coa-GuideMenu__subheading': !isHeading,
           'coa-GuideMenu__current-section': isCurrentSection,
         })}
-        onClick={goToSection}
+        onClick={e => goToSection(e, anchorTag)}
       >
         <span className="coa-GuideMenu__title-text">{title}</span>
       </div>
     </div>
   );
-}
+};
 
-function GuideMenuSection({ section, currentSection }) {
+function GuideMenuSection({ section, currentSection, goToSection }) {
   const headingAnchorTag = hyphenate(section.heading);
   const subHeadings = section.pages.map((page, index) => {
     const title =
@@ -54,6 +54,7 @@ function GuideMenuSection({ section, currentSection }) {
         anchorTag={headingAnchorTag}
         isHeading={true}
         isCurrentSection={currentSection === headingAnchorTag}
+        goToSection={goToSection}
       />
       {subHeadings.map((subHeading, index) => (
         <GuideMenuLink
@@ -62,19 +63,39 @@ function GuideMenuSection({ section, currentSection }) {
           anchorTag={subHeading.anchorTag}
           isHeading={false}
           isCurrentSection={currentSection === subHeading.anchorTag}
+          goToSection={goToSection}
         />
       ))}
     </div>
   );
 }
 
-function GuideMenu({ contact, sections, currentSection, intl }) {
+const GuideMenu = ({ contact, sections, currentSection, intl }) => {
+  const [clickedSection, setClickedSection] = useState(null);
+
+  // Each GuideSectionWrapper has an id={this.props.anchorTag}
+  const goToSection = (e, anchorTag) => {
+    setClickedSection(anchorTag);
+    history.pushState(null, null, `#${anchorTag}`);
+    document.getElementById(anchorTag).scrollIntoView(true);
+  };
+
   useEffect(() => {
     const el = document.getElementById(`menu-${currentSection}`);
     if (el) {
-      el.scrollIntoView();
+      if (clickedSection) {
+        // If we clicked a section, we don't want to mess around with this logic
+        // until we hit that section. This fires every time we scroll to a new
+        // section, and is fired a bunch when the click fires off a scroll
+        if (currentSection === clickedSection) {
+          // We made it! back to business as usual
+          setClickedSection(null);
+        }
+      } else {
+        el.scrollIntoView();
+      }
     }
-  });
+  }, [currentSection]);
 
   return (
     <div>
@@ -85,6 +106,7 @@ function GuideMenu({ contact, sections, currentSection, intl }) {
             anchorTag="Contact-information"
             isHeading={true}
             isCurrentSection={currentSection === 'Contact-information'}
+            goToSection={goToSection}
           />
         )}
       </div>
@@ -93,10 +115,11 @@ function GuideMenu({ contact, sections, currentSection, intl }) {
           key={index}
           section={section}
           currentSection={currentSection}
+          goToSection={goToSection}
         />
       ))}
     </div>
   );
-}
+};
 
 export default injectIntl(GuideMenu);

--- a/src/components/Pages/Guide/GuideMenu.js
+++ b/src/components/Pages/Guide/GuideMenu.js
@@ -77,6 +77,7 @@ const GuideMenu = ({ contact, sections, currentSection, intl }) => {
   useEffect(() => {
     if (location && location.hash) {
       // debugger;
+      console.log(location.hash);
       setClickedSection(location.hash.substring(1));
       document.getElementById(location.hash.substring(1)).scrollIntoView(true);
     }
@@ -85,21 +86,27 @@ const GuideMenu = ({ contact, sections, currentSection, intl }) => {
   }, [location]);
 
   useEffect(() => {
-    const el = document.getElementById(`menu-${currentSection}`);
-    if (el) {
-      if (clickedSection) {
-        // If we clicked a section, we don't want to mess around with this logic
-        // until we hit that section. This fires every time we scroll to a new
-        // section, and is fired a bunch when the click fires off a scroll
-        if (currentSection === clickedSection) {
-          // We made it! back to business as usual
-          setClickedSection(null);
-          el.scrollIntoView();
-        }
-      } else {
-        el.scrollIntoView();
-      }
+    console.log(currentSection);
+    if (currentSection) {
+      history.pushState(null, null, `#${currentSection}`);
     }
+
+    // debugger;
+    // const el = document.getElementById(`menu-${currentSection}`);
+    // if (el) {
+    //   if (clickedSection) {
+    //     // If we clicked a section, we don't want to mess around with this logic
+    //     // until we hit that section. This fires every time we scroll to a new
+    //     // section, and is fired a bunch when the click fires off a scroll
+    //     if (currentSection === clickedSection) {
+    //       // We made it! back to business as usual
+    //       setClickedSection(null);
+    //       el.scrollIntoView(true);
+    //     }
+    //   } else {
+    //     el.scrollIntoView(true);
+    //   }
+    // }
   }, [currentSection]);
 
   return (

--- a/src/components/Pages/Guide/GuideMenu.js
+++ b/src/components/Pages/Guide/GuideMenu.js
@@ -99,7 +99,7 @@ const GuideMenu = ({ contact, sections, currentSection, intl }) => {
      be off by a little bit (existing bug I'm pretty sure)
 
    • scrolling down after clicking a section lower down allows the selected
-     TOC item to be offscreen again (attaching gif for that)
+     TOC item to be offscreen again
 
   Things I've tried:
    • The current implementation (detailed in comments below)


### PR DESCRIPTION
This is a bit of a scope creeper, as we watched "don't let the TOC have a selected item offscreen" turn into "how can we manage scrolling both the TOC and the content on the guide page in all scenarios"

I left a lot of comments that will hopefully aid us in working out some of the more complex issues figured out.

Ideally I'd like to get to the point where we feel this is:
* An improvement from what we have now (TOC never scrolls with content)
* A decent jumping off point for any smaller issues that stem from it
  * See known issues in file comments

Testing link: https://janis-3094-guide-toc-2.netlify.com/en/health-safety/healthcare-prevention/disease-prevention/mobile-food-vendor-permit-guide/#Get-inspected

From the file comments (more or less):

> Dear future developers trying to improve/replace the guide page table of contents/scrolling code, I wish you all the best. 
> 
> In order to work correctly:
> * when a user scrolls:
>   * the current section appears "selected" in the TOC
>   * the current section is on screen in the TOC
> * when loading the page with an anchor link:
>   * the linked section is scrolled to the top
>   * the corresponding TOC section is selected and visible
> * when clicking a link in the TOC
>   * the url is updated to reflect the link anchor
>   * the clicked section is scrolled to the top
>   * the corresponding TOC section is selected and visible
> 
> In this implementation, I have found a few issues, most of them stem from trying to scroll 2 things at once:
> * Table of contents
> * Main content
> 
> Known Issues:
> * if you enter a new anchor link in the url when the page is already loaded, it will scroll to the new section but not update the scrolling on the TOC
> * if we have dynamic content (like recollect that changes height after loading) we don't correctly recalculate the size of the sections, so everything will be off by a little bit (existing bug I'm pretty sure)
> * scrolling down after clicking a section lower down allows the selected TOC item to be offscreen again
> 
> Things I've tried:
> * The current implementation (detailed in comments in code)
> * Playing with setTimeout to fake concurrent scrolling
>   * Using https://www.npmjs.com/package/scroll-into-view
>   * Led to UI freezes
>   * Jumpy scrolling around a bit
> * Another branch (https://github.com/cityofaustin/janis/tree/3094-guide-page-toc) that:
>   * Didn't use any react-router-dom hooks
>   * Didn't use react-router-dom links
>   * Had complex logic including goToSection
>   * Failed super hard when trying to get anchor links to work 
>   