### PR TITLE
3165 - Guide pages on small screens

### DIFF
--- a/src/components/Pages/Guide/_Guide.scss
+++ b/src/components/Pages/Guide/_Guide.scss
@@ -101,6 +101,12 @@ $max-guide-tablet-width: $coa-medium-screen;
   margin-top: $sticky-guide-top;
 }
 
+.coa-GuidePage__content-container {
+  .wrapper {
+    width: 100%;
+  }
+}
+
 .coa-GuidePage__content-container > .wrapper > .row {
   margin-right: 0; //TODO: again, uswds's default .row class has built in -1rem margins!!
 }


### PR DESCRIPTION
fixes https://github.com/cityofaustin/techstack/issues/3165

It looks like the .coa-GuidePage__content-container wrapper was getting too big for the screeen on very small screens ~320px, this led to some odd scrolling behavior, it was hidden on slightly larger ~375px screens, so it was easy enough to miss.