### PR TITLE
3371 - responsive video iframes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # 🌻 Janis ☮️
-## I'm just here to test
 
 Janis is the codename for the software that renders [alpha.austin.gov](https://alpha.austin.gov) for web browsers. It is a working prototype of static site generation front-end and decoupled CMS architecture.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # 🌻 Janis ☮️
+## I'm just here to test
 
 Janis is the codename for the software that renders [alpha.austin.gov](https://alpha.austin.gov) for web browsers. It is a working prototype of static site generation front-end and decoupled CMS architecture.
 

--- a/src/components/HtmlFromAdmin/index.js
+++ b/src/components/HtmlFromAdmin/index.js
@@ -39,6 +39,7 @@ const HtmlFromAdmin = ({ content }) => {
         // This makes wagtail's default video embeds work on small screens
         if (domNode.name === 'iframe') {
           domNode.attribs.width = '100%';
+          domNode.attribs.title = 'Embedded video';
         }
 
         // Turn links into buttons

--- a/src/components/HtmlFromAdmin/index.js
+++ b/src/components/HtmlFromAdmin/index.js
@@ -36,6 +36,11 @@ const HtmlFromAdmin = ({ content }) => {
           return <ReactMarkdown source={content} escapeHtml={false} />;
         }
 
+        // This makes wagtail's default video embeds work on small screens
+        if (domNode.name === 'iframe') {
+          domNode.attribs.width = '100%';
+        }
+
         // Turn links into buttons
         // waiting on
         // if (

--- a/src/components/HtmlFromAdmin/index.js
+++ b/src/components/HtmlFromAdmin/index.js
@@ -42,6 +42,12 @@ const HtmlFromAdmin = ({ content }) => {
           domNode.attribs.title = 'Embedded video';
         }
 
+        if (domNode.attribs.class === 'responsive-object') {
+          // For some reason wagtail chucks a giant margin on the bottom here,
+          // let's clear that out and handle any additional styling using classes
+          domNode.attribs.style = '';
+        }
+
         // Turn links into buttons
         // waiting on
         // if (


### PR DESCRIPTION
Kinda faking it but setting iframes from rich text to 100% width seems to work quite well for our MVP use cases.

Janis app: https://janis-3371-video-embeds.netlify.com/en/health-safety/health-records-certificates-2/birth-death-certificates/video/
joplin app:  http://joplin-pr-3371-video-embeds.herokuapp.com/admin/pages/265/edit/#tab-content
Joplin pr: https://github.com/cityofaustin/joplin/pull/461