### PR TITLE
3263 fix departments page tiles

### DIFF
--- a/src/css/base/_variables.scss
+++ b/src/css/base/_variables.scss
@@ -115,7 +115,7 @@ $coa-header-toprow-height: 55px;
 $coa-languageselectbar-height: 50px;
 $coa-button-border-radius: 4px;
 $coa-tile-height: 242px;
-$coa-tile-min-width: 200px;
+$coa-tile-min-width: 30%;
 $coa-tile-max-width: 310px;
 $coa-tile-group-border-radius: 6px;
 $coa-tile-group-border: 4px;


### PR DESCRIPTION
# Description
Turns out this was an issue for any tilegroup displaying in the standard Topic page style, but it doesn't show up unless we're dealing with a lot of really short names.

Updated a magic number to be more magic.

# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How can this be tested?
https://janis-3263-depts-page.netlify.com/en/departments/
make sure topic pages and the departments page have tiles that look right

# Checklist:
- [x] Request reviewers
- [ ] Slack-out message for review
- [x] Link this PR in the issue
- [x] Moved card to *review* in zenhub
