### PR TITLE
3122 - fix invalid date for Trashy

### DIFF
--- a/src/components/Trashy/TrashySchedule.js
+++ b/src/components/Trashy/TrashySchedule.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, FormattedDate } from 'react-intl';
-import ExternalLink from 'components/ExternalLink';
 import I18nLink from 'components/I18n/I18nLink';
 import { curbsideServices as i18n } from 'js/i18n/definitions';
 import { injectIntl } from 'react-intl';
@@ -19,11 +18,13 @@ const TrashySchedule = props => {
         trash: intl.formatMessage(i18n.trash),
         compost: intl.formatMessage(i18n.compost),
         brushcollection: intl.formatMessage(i18n.brushcollection),
-        bulkitemcollection: (
-          <I18nLink to="bulk-item-pickup">
-            {intl.formatMessage(i18n.bulkitemcollection)}
-          </I18nLink>
-        ),
+        bulkitemcollection: intl.formatMessage(i18n.bulkitemcollection),
+        // removing the link for now, may come back
+        // bulkitemcollection: (
+        //   <I18nLink to="bulk-item-pickup">
+        //     {intl.formatMessage(i18n.bulkitemcollection)}
+        //   </I18nLink>
+        // ),
       };
       return cases[service];
     }
@@ -63,15 +64,9 @@ const TrashySchedule = props => {
     />
   );
 
-  const bulkItemPickupLink = (
-    <I18nLink to="bulk-item-pickup">
-      {intl.formatMessage(i18n.bulkitemcollection)}
-    </I18nLink>
-  );
-
   const bulkItemMessage = nextBulkPickupDate ?
   `${intl.formatMessage(i18n.bulkitemcollection)}: {bulkPickupDate}` 
-  : 'Currently, no upcoming bulk item collection date has been scheduled. Please check back soon.'
+  : intl.formatMessage(i18n.invalidDate)
 
   return (
     <div className="coa-Trashy__schedule-container">

--- a/src/components/Trashy/TrashySchedule.js
+++ b/src/components/Trashy/TrashySchedule.js
@@ -69,7 +69,9 @@ const TrashySchedule = props => {
     </I18nLink>
   );
 
-  const errorMessage = 'Currently, no upcoming bulk item collection date has been scheduled. Please check back soon.'
+  const bulkItemMessage = nextBulkPickupDate ?
+  `${intl.formatMessage(i18n.bulkitemcollection)}: {bulkPickupDate}` 
+  : 'Currently, no upcoming bulk item collection date has been scheduled. Please check back soon.'
 
   return (
     <div className="coa-Trashy__schedule-container">
@@ -82,8 +84,8 @@ const TrashySchedule = props => {
           <h4>
             <FormattedMessage
               id="trashSchedule.bulkPickUp"
-              defaultMessage={nextBulkPickupDate ? 'Next {bulkItemPickupLink}: {bulkPickupDate}' : errorMessage}
-              values={{ bulkPickupDate, bulkItemPickupLink }}
+              defaultMessage={bulkItemMessage}
+              values={{ bulkPickupDate }}
             />
           </h4>
         </div>

--- a/src/components/Trashy/TrashySchedule.js
+++ b/src/components/Trashy/TrashySchedule.js
@@ -69,6 +69,8 @@ const TrashySchedule = props => {
     </I18nLink>
   );
 
+  const errorMessage = 'Currently, no upcoming bulk item collection date has been scheduled. Please check back soon.'
+
   return (
     <div className="coa-Trashy__schedule-container">
       <div className="coa-Trashy__schedule-header">
@@ -80,7 +82,7 @@ const TrashySchedule = props => {
           <h4>
             <FormattedMessage
               id="trashSchedule.bulkPickUp"
-              defaultMessage={'Next {bulkItemPickupLink}: {bulkPickupDate}'}
+              defaultMessage={nextBulkPickupDate ? 'Next {bulkItemPickupLink}: {bulkPickupDate}' : errorMessage}
               values={{ bulkPickupDate, bulkItemPickupLink }}
             />
           </h4>

--- a/src/js/i18n/definitions.js
+++ b/src/js/i18n/definitions.js
@@ -141,6 +141,7 @@ export const curbsideServices = defineMessages({
   brushcollection: 'Large brush collection',
   bulkitemcollection: 'Next bulk item collection',
   pickupschedule: "Here's the pickup schedule for {address}",
+  invalidDate: 'Currently, no upcoming bulk item collection date has been scheduled. Please check back soon.',
 });
 
 export const departmentPage = defineMessages({

--- a/src/js/i18n/definitions.js
+++ b/src/js/i18n/definitions.js
@@ -139,7 +139,7 @@ export const curbsideServices = defineMessages({
   trash: 'Trash',
   compost: 'Compost',
   brushcollection: 'Large brush collection',
-  bulkitemcollection: 'Bulk item collection',
+  bulkitemcollection: 'Next bulk item collection',
   pickupschedule: "Here's the pickup schedule for {address}",
 });
 

--- a/src/js/i18n/locales/es.json
+++ b/src/js/i18n/locales/es.json
@@ -105,5 +105,5 @@
   "officialdocuments.document": "Documento",
   "guides.pageLink": "Visite esta página en alpha.austin.gov",
   "curbsideServices.bulkitemcollection": "Próxima recolección de artículos grandes",
-  "curbsideServices.invalidDate": "Actualmente, no hay recolección de artículos grandes programado. Por favor vuelva  a consultar pronto."
+  "curbsideServices.invalidDate": "Actualmente, no hay recolección de artículos grandes programado. Por favor vuelva a consultar pronto."
 }

--- a/src/js/i18n/locales/es.json
+++ b/src/js/i18n/locales/es.json
@@ -103,5 +103,7 @@
     "Proceso de investigación de quejas",
   "officialdocuments.author": "Autor",
   "officialdocuments.document": "Documento",
-  "guides.pageLink": "Visite esta página en alpha.austin.gov"
+  "guides.pageLink": "Visite esta página en alpha.austin.gov",
+  "curbsideServices.bulkitemcollection": "Próxima recolección de artículos grandes",
+  "curbsideServices.invalidDate": "Actualmente, no hay recolección de artículos grandes programado. Por favor vuelva  a consultar pronto."
 }


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

<!--- include a summary of the change and what it fixes. -->

When Trashy returns and invalid date (aka the pickup isnt scheduled), janis will no longer say Invalid, but instead show an error message. 

Also removed the links and updated some (but not all) of the translations.

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

https://janis-3122-trashy-sched.netlify.com/en/housing-utilities/recycling-trash-and-compost/household-waste/bulk-item-pickup

has an invalid pickup date : 8506 spearman dr
has a scheduled pickup: 3203 hollywood ave

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
