### PR TITLE
attempt to fix TypeError on netlify builds

### DIFF
--- a/netlify/publish-netlify-pr.sh
+++ b/netlify/publish-netlify-pr.sh
@@ -7,4 +7,4 @@ export NODE_PATH='./src'
 # They are updated by Joplin publish commands.
 # If you want to add custom env variable values for your PR branch, set them in branchConfig.js
 
-yarn npm-run-all -p build-css build-js
+yarn npm-run-all build-css build-js


### PR DESCRIPTION
https://github.com/cityofaustin/techstack/issues/3229

There was a race condition in the publisher. Adding environment variables happened after the site was created. So sometimes there would be no CMS_API set at the time of the site's initial build. The Publisher has now been updated to include env variables at the moment of site creation. https://github.com/cityofaustin/publisher/blob/master/src/coa-publisher-mvp/src/helpers/netlify.py

But, build-css and build-js shouldn't be run in parallel anyway. It's an inconsequential change, the fix was really on the publisher.