### PR TITLE
3328 - fix topic card padding

### DIFF
--- a/src/components/Tiles/_TileGroup.scss
+++ b/src/components/Tiles/_TileGroup.scss
@@ -2,8 +2,8 @@
   // margin-left: $coa-container-margin;
   // margin-right: $coa-container-margin;
   max-width: $coa-wrapper-maxwidth;
-  margin-right: auto;
-  margin-left: auto;
+  margin-right: 0;
+  margin-left: 0;
 
   padding: $coa-spacing-large $coa-spacing-medium;
 


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Padding was weird at a smaller breakpoint on the topic cards, because margin was set to auto instead of 0.

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
https://janis-3328-padding-topic-card.netlify.com/en/health-safety/disaster-safety-relief/
to test: At breakpoints between 972pixel width and mobile views, margin is consistent

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [x] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
