### PR TITLE
fixing padding for tiles arrows

### DIFF
--- a/src/components/Tiles/_Tile.scss
+++ b/src/components/Tiles/_Tile.scss
@@ -37,7 +37,7 @@
   margin: 1rem;
   border: 1px solid $coa-color-primary;
   border-radius: $coa-button-border-radius;
-  padding: $coa-spacing-medium $coa-spacing-small;
+  padding: $coa-spacing-medium;
   max-width: $coa-tile-max-width;
 
   &:hover {


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

<!--- include a summary of the change and what it fixes. -->
This will fix the padding issue with the arrows icons on the tiles

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


# How can this be tested?
See: https://github.com/cityofaustin/techstack/issues/3365
Deployed: https://janis-3365-tile-padding-adjustment.netlify.com/

# Checklist:
- [x] Request reviewers
- [ ] Slack-out message for review
- [x] Link this PR in the issue
- [x] Moved card to *review* in zenhub
