### PR TITLE
3500 pending translation

### DIFF
--- a/src/components/PageSections/Header/index.js
+++ b/src/components/PageSections/Header/index.js
@@ -55,6 +55,7 @@ class Header extends Component {
 
   // Hides the menu
   handleClickOutside(event) {
+    console.log(event.target.className)
     // Full site
     if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
       // If we're clicking on the mobile close button, we'll handle this in toggleFullSiteMenu instead
@@ -64,7 +65,7 @@ class Header extends Component {
         // for the pending translation dropdown:
         event.target.parentElement.className !== 'coa-PendingTranslation coa-PendingTranslation--is-open' &&
         event.target.parentElement.className !== 'coa-PendingTranslation--link' &&
-        event.target.className !== 'coa-LanguageSelectBar__item coa-LanguageSelectBar__item--active' &&
+        event.target.className !== 'coa-LanguageSelectBar__item coa-LanguageSelectBar__item--active coa-LanguageSelectBar__item--showMessage' &&
         event.target.className !== 'material-icons coa-LanguageChevron'
       ) {
         this.setState({
@@ -188,8 +189,12 @@ class Header extends Component {
             refnode={this.setHowYouKnowWrapperRef}
           />
           <div className="coa-Header__mobile-languages">
-            <LanguageSelectBar path={path} />
-            <PendingTranslation open />
+            <LanguageSelectBar 
+              path={path}
+              showMessage={this.state.showMessage}
+              togglePendingTranslation={()=>this.togglePendingTranslation()}
+            />
+            <PendingTranslation open={this.state.showMessage} />
           </div>
           <div className="coa-Header__container">
             <div className="coa-Header__controls">

--- a/src/components/PageSections/Header/index.js
+++ b/src/components/PageSections/Header/index.js
@@ -159,10 +159,6 @@ class Header extends Component {
     }
   }
 
-  languageOnClick = () => {
-    this.setState({});
-  }
-
   togglePendingTranslation = () => {
     this.setState(prevState => ({
       showMessage: !prevState.showMessage

--- a/src/components/PageSections/Header/index.js
+++ b/src/components/PageSections/Header/index.js
@@ -63,7 +63,7 @@ class Header extends Component {
         event.target.parentElement.className !== 'coa-Header__menuIcon' &&
         // for the pending translation dropdown:
         event.target.parentElement.className !== 'coa-PendingTranslation coa-PendingTranslation--is-open' &&
-        event.target.parentElement.className !== 'coa-PendingTranslation--link' &&
+        event.target.className !== 'coa-LanguageSelectBar__background coa-LanguageSelectBar__background--active' &&
         event.target.className !== 'coa-LanguageSelectBar__item coa-LanguageSelectBar__item--active coa-LanguageSelectBar__item--showMessage coa-LanguageSelectBar__item--activeMessage' &&
         event.target.className !== 'material-icons coa-LanguageChevron'
       ) {
@@ -171,8 +171,6 @@ class Header extends Component {
 
   render() {
     const { intl, navigation, path } = this.props;
-    console.log(this.state.showMessage);
-    console.log(intl.locale);
 
     return (
       <header
@@ -193,7 +191,7 @@ class Header extends Component {
             <LanguageSelectBar 
               path={path}
               showMessage={this.state.showMessage}
-              togglePendingTranslation={()=>this.togglePendingTranslation()}
+              togglePendingTranslation={() => this.togglePendingTranslation()}
             />
             <PendingTranslation open={this.state.showMessage} />
           </div>

--- a/src/components/PageSections/Header/index.js
+++ b/src/components/PageSections/Header/index.js
@@ -99,6 +99,7 @@ class Header extends Component {
     if (e.key === 'Escape') {
       this.setState({
         topMenuActive: false,
+        showMessage: false,
       });
     }
   };
@@ -128,6 +129,7 @@ class Header extends Component {
       e.preventDefault();
       this.setState({
         topMenuActive: false,
+        showMessage: false,
       });
     }
   };

--- a/src/components/PageSections/Header/index.js
+++ b/src/components/PageSections/Header/index.js
@@ -60,8 +60,10 @@ class Header extends Component {
       // If we're clicking on the mobile close button, we'll handle this in toggleFullSiteMenu instead
       if (
         event.target.className !== 'coa-Header__menuIcon' &&
-        event.target.parentElement.className !== 'coa-Header__menuIcon'
-        // possibly do the same for the pending translation thing?
+        event.target.parentElement.className !== 'coa-Header__menuIcon' &&
+        event.target.parentElement.className !== 'coa-PendingTranslation coa-PendingTranslation--is-open' &&
+        event.target.parentElement.className !== 'coa-PendingTranslation--link' &&
+        event.target.className !== 'coa-LanguageSelectBar__item coa-LanguageSelectBar__item--active'
       ) {
         this.setState({
           topMenuActive: false,
@@ -157,15 +159,14 @@ class Header extends Component {
     this.setState({});
   }
 
-  togglePendingTranslation = (intl) => {
-    console.log(intl.locale)
-    this.setState({showMessage: intl.locale === 'es'});
+  togglePendingTranslation = () => {
+    this.setState(prevState => ({
+      showMessage: !prevState.showMessage
+    }))
   }
 
   render() {
     const { intl, navigation, path } = this.props;
-
-    console.log('showMessage', this.state.showMessage)
 
     return (
       <header
@@ -193,7 +194,7 @@ class Header extends Component {
                   <LanguageSelectBar 
                     path={path} 
                     showMessage={this.state.showMessage}
-                    togglePendingTranslation={() => this.togglePendingTranslation(intl)}
+                    togglePendingTranslation={() => this.togglePendingTranslation()}
                   />
                   <PendingTranslation open={this.state.showMessage} />
                 </div>

--- a/src/components/PageSections/Header/index.js
+++ b/src/components/PageSections/Header/index.js
@@ -55,7 +55,6 @@ class Header extends Component {
 
   // Hides the menu
   handleClickOutside(event) {
-    console.log(event.target.className)
     // Full site
     if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
       // If we're clicking on the mobile close button, we'll handle this in toggleFullSiteMenu instead
@@ -65,7 +64,7 @@ class Header extends Component {
         // for the pending translation dropdown:
         event.target.parentElement.className !== 'coa-PendingTranslation coa-PendingTranslation--is-open' &&
         event.target.parentElement.className !== 'coa-PendingTranslation--link' &&
-        event.target.className !== 'coa-LanguageSelectBar__item coa-LanguageSelectBar__item--active coa-LanguageSelectBar__item--showMessage' &&
+        event.target.className !== 'coa-LanguageSelectBar__item coa-LanguageSelectBar__item--active coa-LanguageSelectBar__item--showMessage coa-LanguageSelectBar__item--activeMessage' &&
         event.target.className !== 'material-icons coa-LanguageChevron'
       ) {
         this.setState({

--- a/src/components/PageSections/Header/index.js
+++ b/src/components/PageSections/Header/index.js
@@ -63,6 +63,7 @@ class Header extends Component {
         event.target.parentElement.className !== 'coa-Header__menuIcon' &&
         // for the pending translation dropdown:
         event.target.parentElement.className !== 'coa-PendingTranslation coa-PendingTranslation--is-open' &&
+        event.target.parentElement.className !== 'coa-PendingTranslation--link' &&
         event.target.className !== 'coa-LanguageSelectBar__background coa-LanguageSelectBar__background--active' &&
         event.target.className !== 'coa-LanguageSelectBar__item coa-LanguageSelectBar__item--active coa-LanguageSelectBar__item--showMessage coa-LanguageSelectBar__item--activeMessage' &&
         event.target.className !== 'material-icons coa-LanguageChevron'

--- a/src/components/PageSections/Header/index.js
+++ b/src/components/PageSections/Header/index.js
@@ -148,6 +148,11 @@ class Header extends Component {
     }
   }
 
+  toggleTranslationMessage = (intl) => {
+    console.log('what', intl.locale)
+    return intl.locale === 'es';
+  }
+
   render() {
     const { intl, navigation, path } = this.props;
 
@@ -175,7 +180,7 @@ class Header extends Component {
               <div className="coa-Header__left-controls">
                 <div className="coa-Header__desktop-languages">
                   <LanguageSelectBar path={path} chevron={intl.locale ==='es'}/>
-                  <PendingTranslation open={intl.locale === 'es'} />
+                  <PendingTranslation open={this.toggleTranslationMessage(intl)} />
                 </div>
               </div>
               <div

--- a/src/components/PageSections/Header/index.js
+++ b/src/components/PageSections/Header/index.js
@@ -12,6 +12,7 @@ import LanguageSelectBar from 'components/PageSections/LanguageSelectBar';
 import HowYouKnowMenu from 'components/PageSections/HowYouKnowMenu';
 import { themePropTypes } from 'components/PageSections/Menu/proptypes';
 import GovSite from 'components/PageSections/Header/GovSite';
+import PendingTranslation from 'components/PageSections/PendingTranslation'
 
 import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
 import FullSiteMenu from '../Menu/FullSiteMenu';
@@ -167,12 +168,14 @@ class Header extends Component {
           />
           <div className="coa-Header__mobile-languages">
             <LanguageSelectBar path={path} />
+            <PendingTranslation open />
           </div>
           <div className="coa-Header__container">
             <div className="coa-Header__controls">
               <div className="coa-Header__left-controls">
                 <div className="coa-Header__desktop-languages">
-                  <LanguageSelectBar path={path} />
+                  <LanguageSelectBar path={path} chevron={intl.locale ==='es'}/>
+                  <PendingTranslation open={intl.locale === 'es'} />
                 </div>
               </div>
               <div

--- a/src/components/PageSections/Header/index.js
+++ b/src/components/PageSections/Header/index.js
@@ -61,9 +61,11 @@ class Header extends Component {
       if (
         event.target.className !== 'coa-Header__menuIcon' &&
         event.target.parentElement.className !== 'coa-Header__menuIcon' &&
+        // for the pending translation dropdown:
         event.target.parentElement.className !== 'coa-PendingTranslation coa-PendingTranslation--is-open' &&
         event.target.parentElement.className !== 'coa-PendingTranslation--link' &&
-        event.target.className !== 'coa-LanguageSelectBar__item coa-LanguageSelectBar__item--active'
+        event.target.className !== 'coa-LanguageSelectBar__item coa-LanguageSelectBar__item--active' &&
+        event.target.className !== 'material-icons coa-LanguageChevron'
       ) {
         this.setState({
           topMenuActive: false,

--- a/src/components/PageSections/Header/index.js
+++ b/src/components/PageSections/Header/index.js
@@ -169,6 +169,10 @@ class Header extends Component {
     }))
   }
 
+  closeMessage = () => {
+    this.setState({ showMessage: false })
+  }
+
   render() {
     const { intl, navigation, path } = this.props;
 
@@ -193,7 +197,10 @@ class Header extends Component {
               showMessage={this.state.showMessage}
               togglePendingTranslation={() => this.togglePendingTranslation()}
             />
-            <PendingTranslation open={this.state.showMessage} />
+            <PendingTranslation
+              open={this.state.showMessage}
+              closeMessage={()=>this.closeMessage()}
+            />
           </div>
           <div className="coa-Header__container">
             <div className="coa-Header__controls">
@@ -204,7 +211,10 @@ class Header extends Component {
                     showMessage={this.state.showMessage}
                     togglePendingTranslation={() => this.togglePendingTranslation()}
                   />
-                  <PendingTranslation open={this.state.showMessage} />
+                  <PendingTranslation
+                    open={this.state.showMessage}
+                    closeMessage={()=>this.closeMessage()}
+                  />
                 </div>
               </div>
               <div
@@ -249,7 +259,6 @@ class Header extends Component {
           </div>
 
           <FullSiteMenu
-            // ref={node => this.node = node}
             refnode={this.setWrapperRef}
             navigation={navigation}
             handleFullSiteMenuItem={this.closeFullSiteMenuItem}

--- a/src/components/PageSections/Header/index.js
+++ b/src/components/PageSections/Header/index.js
@@ -93,6 +93,7 @@ class Header extends Component {
       e.preventDefault();
       this.setState({
         topMenuActive: true,
+        showMessage: false,
       });
     }
 
@@ -138,6 +139,7 @@ class Header extends Component {
   toggleFullSiteMenu = () => {
     this.setState(prevState => ({
       topMenuActive: !prevState.topMenuActive,
+      showMessage: false,
     }));
   };
 
@@ -162,7 +164,8 @@ class Header extends Component {
 
   togglePendingTranslation = () => {
     this.setState(prevState => ({
-      showMessage: !prevState.showMessage
+      showMessage: !prevState.showMessage,
+      topMenuActive: false,
     }))
   }
 

--- a/src/components/PageSections/Header/index.js
+++ b/src/components/PageSections/Header/index.js
@@ -23,13 +23,16 @@ class Header extends Component {
     this.state = {
       howYouKnowMenuIsOpen: false,
       topMenuActive: false,
+      showMessage: false,
     };
 
     // Bind wrappers and outside-click functions
     this.setWrapperRef = this.setWrapperRef.bind(this);
     this.setHowYouKnowWrapperRef = this.setHowYouKnowWrapperRef.bind(this);
     this.handleClickOutside = this.handleClickOutside.bind(this);
+    this.togglePendingTranslation = this.togglePendingTranslation.bind(this);
   }
+
   componentDidMount() {
     document.addEventListener('mousedown', this.handleClickOutside);
     document.addEventListener('touchstart', this.handleClickOutside);
@@ -58,9 +61,11 @@ class Header extends Component {
       if (
         event.target.className !== 'coa-Header__menuIcon' &&
         event.target.parentElement.className !== 'coa-Header__menuIcon'
+        // possibly do the same for the pending translation thing?
       ) {
         this.setState({
           topMenuActive: false,
+          showMessage: false,
         });
       }
     }
@@ -152,13 +157,15 @@ class Header extends Component {
     this.setState({});
   }
 
-  toggleTranslationMessage = (intl) => {
-    console.log('what', intl.locale)
-    return intl.locale === 'es';
+  togglePendingTranslation = (intl) => {
+    console.log(intl.locale)
+    this.setState({showMessage: intl.locale === 'es'});
   }
 
   render() {
     const { intl, navigation, path } = this.props;
+
+    console.log('showMessage', this.state.showMessage)
 
     return (
       <header
@@ -183,8 +190,12 @@ class Header extends Component {
             <div className="coa-Header__controls">
               <div className="coa-Header__left-controls">
                 <div className="coa-Header__desktop-languages">
-                  <LanguageSelectBar path={path} chevron={intl.locale ==='es'}/>
-                  <PendingTranslation open={this.toggleTranslationMessage(intl)} />
+                  <LanguageSelectBar 
+                    path={path} 
+                    showMessage={this.state.showMessage}
+                    togglePendingTranslation={() => this.togglePendingTranslation(intl)}
+                  />
+                  <PendingTranslation open={this.state.showMessage} />
                 </div>
               </div>
               <div

--- a/src/components/PageSections/Header/index.js
+++ b/src/components/PageSections/Header/index.js
@@ -148,6 +148,10 @@ class Header extends Component {
     }
   }
 
+  languageOnClick = () => {
+    this.setState({});
+  }
+
   toggleTranslationMessage = (intl) => {
     console.log('what', intl.locale)
     return intl.locale === 'es';

--- a/src/components/PageSections/Header/index.js
+++ b/src/components/PageSections/Header/index.js
@@ -171,6 +171,8 @@ class Header extends Component {
 
   render() {
     const { intl, navigation, path } = this.props;
+    console.log(this.state.showMessage);
+    console.log(intl.locale);
 
     return (
       <header

--- a/src/components/PageSections/LanguageSelectBar/_LanguageSelectBar.scss
+++ b/src/components/PageSections/LanguageSelectBar/_LanguageSelectBar.scss
@@ -1,6 +1,5 @@
 .coa-LanguageSelectBar {
-  // background-color: $coa-color-primary;
-  background-color: #FF1493;
+  background-color: $coa-color-primary;
   color: $coa-color-white;
   font-family: $coa-font-sans;
 }

--- a/src/components/PageSections/LanguageSelectBar/_LanguageSelectBar.scss
+++ b/src/components/PageSections/LanguageSelectBar/_LanguageSelectBar.scss
@@ -82,6 +82,9 @@
   &.coa-LanguageSelectBar__item--showMessage {
     color: $coa-color-almost-black;
   }
+  coa-LanguageSelectBar__item--activeMessage {
+    color: $coa-color-primary;
+  }
 }
 
 .coa-LanguageChevron {

--- a/src/components/PageSections/LanguageSelectBar/_LanguageSelectBar.scss
+++ b/src/components/PageSections/LanguageSelectBar/_LanguageSelectBar.scss
@@ -12,10 +12,12 @@
   align-items: center;
   display: flex;
   flex-direction: row;
-  justify-content: center;
+  justify-content: flex-start;
+  padding-left: 15px;
   @include media($coa-medium-screen) {
     justify-content: flex-end;
     // border-left: 1px solid #407CE2;
+    padding-left: 0px;
   }
 
   li {
@@ -28,7 +30,6 @@
 }
 
 .coa-LanguageSelectBar__background {
-  background: $coa-color-white;
   display: none;
   position: absolute;
   width: 100%;
@@ -39,11 +40,15 @@
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
   @include media($coa-medium-screen) {
     margin-left: -15px;
+    background: $coa-color-white;
   }
 }
 
 .coa-LanguageSelectBar__background--active {
-  display: inherit;
+  // should not be shown on mobile ever
+  @include media($coa-medium-screen) {
+    display: inherit;
+  }
   z-index: 0;
   height: 50px;
 }

--- a/src/components/PageSections/LanguageSelectBar/_LanguageSelectBar.scss
+++ b/src/components/PageSections/LanguageSelectBar/_LanguageSelectBar.scss
@@ -82,7 +82,7 @@
   &.coa-LanguageSelectBar__item--showMessage {
     color: $coa-color-almost-black;
   }
-  coa-LanguageSelectBar__item--activeMessage {
+  &.coa-LanguageSelectBar__item--activeMessage {
     color: $coa-color-primary;
   }
 }

--- a/src/components/PageSections/LanguageSelectBar/_LanguageSelectBar.scss
+++ b/src/components/PageSections/LanguageSelectBar/_LanguageSelectBar.scss
@@ -2,6 +2,7 @@
   background-color: $coa-color-primary;
   color: $coa-color-white;
   font-family: $coa-font-sans;
+  z-index: 1;
 }
 
 .coa-LanguageSelectBar__list {
@@ -20,6 +21,32 @@
   li {
     margin: 0;
   }
+}
+
+.coa-LanguageSelectBar__list--showMessage {
+  background-color: $coa-color-white;
+}
+
+.test-hidden {
+  background: $coa-color-white;
+  display: none;
+  position: absolute;
+  width: 100%;
+  max-width: 375px;
+  border-radius: 4px 4px 0px 0px;
+  border-color: #1493FF;
+  border-width: 1px;
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+  height: 1rem;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
+}
+
+.test-shown {
+  display: inherit;
+  z-index: 0;
+  height: 50px;
 }
 
 .coa-rtl {
@@ -51,6 +78,9 @@
     opacity: 1;
     font-weight: 600;
   }
+  &.coa-LanguageSelectBar__item--showMessage {
+  color: $coa-color-almost-black;
+}
 }
 
 .coa-LanguageChevron {

--- a/src/components/PageSections/LanguageSelectBar/_LanguageSelectBar.scss
+++ b/src/components/PageSections/LanguageSelectBar/_LanguageSelectBar.scss
@@ -29,10 +29,11 @@
 
 .test-hidden {
   background: $coa-color-white;
+  margin-left: -15px;
   display: none;
   position: absolute;
   width: 100%;
-  max-width: 375px;
+  max-width: 365px;
   border-radius: 4px 4px 0px 0px;
   border-color: #1493FF;
   border-width: 1px;
@@ -79,8 +80,8 @@
     font-weight: 600;
   }
   &.coa-LanguageSelectBar__item--showMessage {
-  color: $coa-color-almost-black;
-}
+    color: $coa-color-almost-black;
+  }
 }
 
 .coa-LanguageChevron {

--- a/src/components/PageSections/LanguageSelectBar/_LanguageSelectBar.scss
+++ b/src/components/PageSections/LanguageSelectBar/_LanguageSelectBar.scss
@@ -92,5 +92,6 @@
 
 .coa-LanguageChevron {
   position: relative;
-  top: 6px;
+  top: 3px;
+  font-size: 1.8rem;
 }

--- a/src/components/PageSections/LanguageSelectBar/_LanguageSelectBar.scss
+++ b/src/components/PageSections/LanguageSelectBar/_LanguageSelectBar.scss
@@ -2,7 +2,7 @@
   background-color: $coa-color-primary;
   color: $coa-color-white;
   font-family: $coa-font-sans;
-  z-index: 1;
+  z-index: 0;
 }
 
 .coa-LanguageSelectBar__list {

--- a/src/components/PageSections/LanguageSelectBar/_LanguageSelectBar.scss
+++ b/src/components/PageSections/LanguageSelectBar/_LanguageSelectBar.scss
@@ -1,5 +1,6 @@
 .coa-LanguageSelectBar {
-  background-color: $coa-color-primary;
+  // background-color: $coa-color-primary;
+  background-color: #FF1493;
   color: $coa-color-white;
   font-family: $coa-font-sans;
 }
@@ -51,4 +52,9 @@
     opacity: 1;
     font-weight: 600;
   }
+}
+
+.coa-LanguageChevron {
+  position: relative;
+  top: 6px;
 }

--- a/src/components/PageSections/LanguageSelectBar/_LanguageSelectBar.scss
+++ b/src/components/PageSections/LanguageSelectBar/_LanguageSelectBar.scss
@@ -27,9 +27,8 @@
   background-color: $coa-color-white;
 }
 
-.test-hidden {
+.coa-LanguageSelectBar__background {
   background: $coa-color-white;
-  margin-left: -15px;
   display: none;
   position: absolute;
   width: 100%;
@@ -37,14 +36,13 @@
   border-radius: 4px 4px 0px 0px;
   border-color: #1493FF;
   border-width: 1px;
-  align-items: center;
-  flex-direction: column;
-  justify-content: center;
-  height: 1rem;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
+  @include media($coa-medium-screen) {
+    margin-left: -15px;
+  }
 }
 
-.test-shown {
+.coa-LanguageSelectBar__background--active {
   display: inherit;
   z-index: 0;
   height: 50px;

--- a/src/components/PageSections/LanguageSelectBar/index.js
+++ b/src/components/PageSections/LanguageSelectBar/index.js
@@ -15,29 +15,30 @@ const LanguageChevron = ({ showMessage, pending, selected}) => (
 
 const LanguageSelectBar = ({ path, intl, showMessage, togglePendingTranslation }) => (
   <>
-      <div className={classNames("coa-LanguageSelectBar__background", {
+    <div className={classNames("coa-LanguageSelectBar__background", {
       "coa-LanguageSelectBar__background--active": showMessage
-    })}> </div>
-  <div className="coa-LanguageSelectBar">
-    <ul className={classNames("coa-LanguageSelectBar__list", {
-      "coa-LanguageSelectBar__list--showMessage": showMessage,
-    })}>
-      {SUPPORTED_LANGUAGES.map(({ title, abbr, code, pending }, i) => (
-        <li key={i} onClick={pending && togglePendingTranslation}>
-          <Link
-            to={`/${code}/${path}`}
-            className={classNames('coa-LanguageSelectBar__item', {
-              'coa-LanguageSelectBar__item--active': intl.locale === code,
-              'coa-LanguageSelectBar__item--showMessage': showMessage,
-              'coa-LanguageSelectBar__item--activeMessage': (showMessage && intl.locale === code),
-            })}
-          >
-            {title} <LanguageChevron pending={pending} selected={code===intl.locale} showMessage={showMessage} />
-          </Link>
-        </li>
-      ))}
-    </ul>
-  </div>
+    })} />
+    <div className="coa-LanguageSelectBar">
+      <ul className={classNames("coa-LanguageSelectBar__list", {
+        "coa-LanguageSelectBar__list--showMessage": showMessage,
+      })}>
+        {SUPPORTED_LANGUAGES.map(({ title, abbr, code, pending }, i) => {
+          return (
+          <li key={i} onClick={pending && togglePendingTranslation}>
+            <Link
+              to={`/${code}/${path}`}
+              className={classNames('coa-LanguageSelectBar__item', {
+                'coa-LanguageSelectBar__item--active': intl.locale === code,
+                'coa-LanguageSelectBar__item--showMessage': showMessage,
+                'coa-LanguageSelectBar__item--activeMessage': (showMessage && intl.locale === code),
+              })}
+            >
+              {title} <LanguageChevron pending={pending} selected={code===intl.locale} showMessage={showMessage} />
+            </Link>
+          </li>
+        )})}
+      </ul>
+    </div>
   </>
 );
 

--- a/src/components/PageSections/LanguageSelectBar/index.js
+++ b/src/components/PageSections/LanguageSelectBar/index.js
@@ -5,7 +5,13 @@ import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 import { SUPPORTED_LANGUAGES } from 'js/i18n/constants';
 
-const LanguageSelectBar = ({ path, intl }) => (
+const LanguageChevron = ({ intl, code, chevron}) => (
+  (chevron && (intl.locale === 'es') && (code===intl.locale))
+  ? <i className="material-icons coa-LanguageChevron">keyboard_arrow_up</i>
+  : null
+);
+
+const LanguageSelectBar = ({ path, intl, chevron }) => (
   <div className="coa-LanguageSelectBar">
     <ul className="coa-LanguageSelectBar__list">
       {SUPPORTED_LANGUAGES.map(({ title, abbr, code }, i) => (
@@ -16,7 +22,7 @@ const LanguageSelectBar = ({ path, intl }) => (
               'coa-LanguageSelectBar__item--active': intl.locale === code,
             })}
           >
-            {title}
+            {title} <LanguageChevron intl={intl} code={code} chevron={chevron} />
           </Link>
         </li>
       ))}

--- a/src/components/PageSections/LanguageSelectBar/index.js
+++ b/src/components/PageSections/LanguageSelectBar/index.js
@@ -29,7 +29,7 @@ const LanguageSelectBar = ({ path, intl, showMessage, togglePendingTranslation }
             className={classNames('coa-LanguageSelectBar__item', {
               'coa-LanguageSelectBar__item--active': intl.locale === code,
               'coa-LanguageSelectBar__item--showMessage': showMessage,
-              'coa-LanguageSelectBar__item--activeMessage': showMessage && intl.locale === code,
+              'coa-LanguageSelectBar__item--activeMessage': (showMessage && intl.locale === code),
             })}
           >
             {title} <LanguageChevron pending={pending} selected={code===intl.locale} showMessage={showMessage} />

--- a/src/components/PageSections/LanguageSelectBar/index.js
+++ b/src/components/PageSections/LanguageSelectBar/index.js
@@ -5,24 +5,26 @@ import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 import { SUPPORTED_LANGUAGES } from 'js/i18n/constants';
 
-const LanguageChevron = ({ intl, code, chevron}) => (
-  (chevron && (intl.locale === 'es') && (code===intl.locale))
-  ? <i className="material-icons coa-LanguageChevron">keyboard_arrow_up</i>
+const LanguageChevron = ({ showMessage, pending, selected}) => (
+  (pending && selected)
+  ? <i className="material-icons coa-LanguageChevron">
+    { showMessage ? "keyboard_arrow_up" : "keyboard_arrow_down" }
+  </i>
   : null
 );
 
-const LanguageSelectBar = ({ path, intl, chevron }) => (
+const LanguageSelectBar = ({ path, intl, showMessage, togglePendingTranslation }) => (
   <div className="coa-LanguageSelectBar">
     <ul className="coa-LanguageSelectBar__list">
-      {SUPPORTED_LANGUAGES.map(({ title, abbr, code }, i) => (
-        <li key={i} onClick={()=>console.log('hiii')}>
+      {SUPPORTED_LANGUAGES.map(({ title, abbr, code, pending }, i) => (
+        <li key={i} onClick={togglePendingTranslation}>
           <Link
             to={`/${code}/${path}`}
             className={classNames('coa-LanguageSelectBar__item', {
               'coa-LanguageSelectBar__item--active': intl.locale === code,
             })}
           >
-            {title} <LanguageChevron intl={intl} code={code} chevron={chevron} />
+            {title} <LanguageChevron pending={pending} selected={code===intl.locale} showMessage={showMessage} />
           </Link>
         </li>
       ))}

--- a/src/components/PageSections/LanguageSelectBar/index.js
+++ b/src/components/PageSections/LanguageSelectBar/index.js
@@ -17,7 +17,7 @@ const LanguageSelectBar = ({ path, intl, showMessage, togglePendingTranslation }
   <div className="coa-LanguageSelectBar">
     <ul className="coa-LanguageSelectBar__list">
       {SUPPORTED_LANGUAGES.map(({ title, abbr, code, pending }, i) => (
-        <li key={i} onClick={togglePendingTranslation}>
+        <li key={i} onClick={pending && togglePendingTranslation}>
           <Link
             to={`/${code}/${path}`}
             className={classNames('coa-LanguageSelectBar__item', {

--- a/src/components/PageSections/LanguageSelectBar/index.js
+++ b/src/components/PageSections/LanguageSelectBar/index.js
@@ -29,6 +29,7 @@ const LanguageSelectBar = ({ path, intl, showMessage, togglePendingTranslation }
             className={classNames('coa-LanguageSelectBar__item', {
               'coa-LanguageSelectBar__item--active': intl.locale === code,
               'coa-LanguageSelectBar__item--showMessage': showMessage,
+              'coa-LanguageSelectBar__item--activeMessage': showMessage && intl.locale === code,
             })}
           >
             {title} <LanguageChevron pending={pending} selected={code===intl.locale} showMessage={showMessage} />

--- a/src/components/PageSections/LanguageSelectBar/index.js
+++ b/src/components/PageSections/LanguageSelectBar/index.js
@@ -15,7 +15,7 @@ const LanguageSelectBar = ({ path, intl, chevron }) => (
   <div className="coa-LanguageSelectBar">
     <ul className="coa-LanguageSelectBar__list">
       {SUPPORTED_LANGUAGES.map(({ title, abbr, code }, i) => (
-        <li key={i}>
+        <li key={i} onClick={()=>console.log('hiii')}>
           <Link
             to={`/${code}/${path}`}
             className={classNames('coa-LanguageSelectBar__item', {

--- a/src/components/PageSections/LanguageSelectBar/index.js
+++ b/src/components/PageSections/LanguageSelectBar/index.js
@@ -15,8 +15,8 @@ const LanguageChevron = ({ showMessage, pending, selected}) => (
 
 const LanguageSelectBar = ({ path, intl, showMessage, togglePendingTranslation }) => (
   <>
-      <div className={classNames("test-hidden", {
-      "test-shown": showMessage
+      <div className={classNames("coa-LanguageSelectBar__background", {
+      "coa-LanguageSelectBar__background--active": showMessage
     })}> </div>
   <div className="coa-LanguageSelectBar">
     <ul className={classNames("coa-LanguageSelectBar__list", {

--- a/src/components/PageSections/LanguageSelectBar/index.js
+++ b/src/components/PageSections/LanguageSelectBar/index.js
@@ -14,14 +14,21 @@ const LanguageChevron = ({ showMessage, pending, selected}) => (
 );
 
 const LanguageSelectBar = ({ path, intl, showMessage, togglePendingTranslation }) => (
+  <>
+      <div className={classNames("test-hidden", {
+      "test-shown": showMessage
+    })}> </div>
   <div className="coa-LanguageSelectBar">
-    <ul className="coa-LanguageSelectBar__list">
+    <ul className={classNames("coa-LanguageSelectBar__list", {
+      "coa-LanguageSelectBar__list--showMessage": showMessage,
+    })}>
       {SUPPORTED_LANGUAGES.map(({ title, abbr, code, pending }, i) => (
         <li key={i} onClick={pending && togglePendingTranslation}>
           <Link
             to={`/${code}/${path}`}
             className={classNames('coa-LanguageSelectBar__item', {
               'coa-LanguageSelectBar__item--active': intl.locale === code,
+              'coa-LanguageSelectBar__item--showMessage': showMessage,
             })}
           >
             {title} <LanguageChevron pending={pending} selected={code===intl.locale} showMessage={showMessage} />
@@ -30,6 +37,7 @@ const LanguageSelectBar = ({ path, intl, showMessage, togglePendingTranslation }
       ))}
     </ul>
   </div>
+  </>
 );
 
 LanguageSelectBar.propTypes = {

--- a/src/components/PageSections/PendingTranslation/_PendingTranslation.scss
+++ b/src/components/PageSections/PendingTranslation/_PendingTranslation.scss
@@ -2,7 +2,7 @@
   top: 90px;
   background: $coa-color-white;
   display: none;
-  position: fixed;
+  position: absolute;
   width: 100%;
   max-width: 375px;
   border-radius: 4px;
@@ -11,7 +11,7 @@
   align-items: center;
   flex-direction: column;
   justify-content: center;
-  padding: 20px;
+  padding: 15px;
 }
 
 .coa-PendingTranslation--is-open {

--- a/src/components/PageSections/PendingTranslation/_PendingTranslation.scss
+++ b/src/components/PageSections/PendingTranslation/_PendingTranslation.scss
@@ -24,10 +24,6 @@
   z-index: 1;
 }
 
-.coa-PendingTranslation--languages {
-  
-}
-
 .coa-PendingTranslation p {
   color:  $coa-color-almost-black;
   font-size: $coa-font-size-xsmall;

--- a/src/components/PageSections/PendingTranslation/_PendingTranslation.scss
+++ b/src/components/PageSections/PendingTranslation/_PendingTranslation.scss
@@ -3,8 +3,6 @@
   display: none;
   position: absolute;
   width: 100%;
-  max-width: 365px;
-  border-radius: 0px 0px 4px 4px;
   border-color: #1493FF;
   border-width: 1px;
   align-items: center;
@@ -16,6 +14,8 @@
   @include media($coa-medium-screen) {
     margin-left: -15px;
     top: 90px;
+    max-width: 365px;
+    border-radius: 0px 0px 4px 4px;
   }
 }
 

--- a/src/components/PageSections/PendingTranslation/_PendingTranslation.scss
+++ b/src/components/PageSections/PendingTranslation/_PendingTranslation.scss
@@ -12,6 +12,7 @@
   flex-direction: column;
   justify-content: center;
   padding: 15px;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
 }
 
 .coa-PendingTranslation--is-open {

--- a/src/components/PageSections/PendingTranslation/_PendingTranslation.scss
+++ b/src/components/PageSections/PendingTranslation/_PendingTranslation.scss
@@ -1,0 +1,30 @@
+.coa-PendingTranslation {
+  top: 90px;
+  background: $coa-color-white;
+  display: none;
+  position: fixed;
+  width: 100%;
+  max-width: 375px;
+  border-radius: 4px;
+  border-color: #1493FF;
+  border-width: 1px;
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+  padding: 20px;
+}
+
+.coa-PendingTranslation--is-open {
+  display: inherit;
+  z-index: 1;
+}
+
+.coa-PendingTranslation--languages {
+  
+}
+
+.coa-PendingTranslation p {
+  color:  $coa-color-almost-black;
+  font-size: $coa-font-size-xsmall;
+  line-height: $coa-line-height-xsmall;
+}

--- a/src/components/PageSections/PendingTranslation/_PendingTranslation.scss
+++ b/src/components/PageSections/PendingTranslation/_PendingTranslation.scss
@@ -1,7 +1,5 @@
 .coa-PendingTranslation {
-  top: 90px;
   background: $coa-color-white;
-  margin-left: -15px;
   display: none;
   position: absolute;
   width: 100%;
@@ -15,6 +13,10 @@
   padding: 0px 15px;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
   border-top: 1px solid  #c6cace;
+  @include media($coa-medium-screen) {
+    margin-left: -15px;
+    top: 90px;
+  }
 }
 
 .coa-PendingTranslation--is-open {

--- a/src/components/PageSections/PendingTranslation/_PendingTranslation.scss
+++ b/src/components/PageSections/PendingTranslation/_PendingTranslation.scss
@@ -1,18 +1,20 @@
 .coa-PendingTranslation {
   top: 90px;
   background: $coa-color-white;
+  margin-left: -15px;
   display: none;
   position: absolute;
   width: 100%;
-  max-width: 375px;
-  border-radius: 4px;
+  max-width: 365px;
+  border-radius: 0px 0px 4px 4px;
   border-color: #1493FF;
   border-width: 1px;
   align-items: center;
   flex-direction: column;
   justify-content: center;
-  padding: 15px;
+  padding: 0px 15px;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
+  border-top: 1px solid  #c6cace;
 }
 
 .coa-PendingTranslation--is-open {

--- a/src/components/PageSections/PendingTranslation/index.js
+++ b/src/components/PageSections/PendingTranslation/index.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl } from 'react-intl';
+import classNames from 'classnames';
+
+import { howYouKnowMenu as i18n } from 'js/i18n/definitions';
+
+const PendingTranslation = ({ open, intl }) => (
+  <div
+    className={classNames('coa-PendingTranslation', {
+      'coa-PendingTranslation--is-open': open,
+    })}
+  >
+    <p>Translations for this website are a work in progress.</p>
+    <p>If you would like to help us improve, please sign-up to participate in user research. 
+    [https://alpha.austin.gov/es/feedback/]</p>
+  </div>
+);
+
+PendingTranslation.propTypes = {
+  open: PropTypes.bool.isRequired,
+};
+
+export default injectIntl(PendingTranslation);

--- a/src/components/PageSections/PendingTranslation/index.js
+++ b/src/components/PageSections/PendingTranslation/index.js
@@ -6,7 +6,7 @@ import { Link } from 'react-router-dom';
 
 import { howYouKnowMenu as i18n } from 'js/i18n/definitions';
 
-const PendingTranslation = ({ open, intl }) => (
+const PendingTranslation = ({ open, intl, closeMessage }) => (
   <div
     className={classNames('coa-PendingTranslation', {
       'coa-PendingTranslation--is-open': open,
@@ -15,9 +15,10 @@ const PendingTranslation = ({ open, intl }) => (
     <p>Continuamos trabajando y procesando las traducciones en este sitio web.</p>
     <p className='coa-PendingTranslation--link'>
       Si le gustaría ayudarnos a mejorar, por favor inscríbase para participar en nuestras investigaciones de usuarios {' '}
-      <Link to={'/es/feedback/'}>
+      <Link to={'/es/feedback/'} onClick={closeMessage}>
         https://alpha.austin.gov/es/feedback/
-      </Link></p>
+      </Link>
+    </p>
   </div>
 );
 

--- a/src/components/PageSections/PendingTranslation/index.js
+++ b/src/components/PageSections/PendingTranslation/index.js
@@ -14,7 +14,7 @@ const PendingTranslation = ({ open, intl }) => (
   >
     <p>Continuamos trabajando y procesando las traducciones en este sitio web.</p>
     <p className='coa-PendingTranslation--link'>
-      Si le gustaría ayudarnos a mejorar, por favor inscríbase para participar en nuestras investigaciones de usuarios 
+      Si le gustaría ayudarnos a mejorar, por favor inscríbase para participar en nuestras investigaciones de usuarios {' '}
       <Link to={'/es/feedback/'}>
         https://alpha.austin.gov/es/feedback/
       </Link></p>

--- a/src/components/PageSections/PendingTranslation/index.js
+++ b/src/components/PageSections/PendingTranslation/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import classNames from 'classnames';
+import { Link } from 'react-router-dom';
 
 import { howYouKnowMenu as i18n } from 'js/i18n/definitions';
 
@@ -12,8 +13,10 @@ const PendingTranslation = ({ open, intl }) => (
     })}
   >
     <p>Translations for this website are a work in progress.</p>
-    <p>If you would like to help us improve, please sign-up to participate in user research. 
-    [https://alpha.austin.gov/es/feedback/]</p>
+    <p className='coa-PendingTranslation--link'>If you would like to help us improve, please sign-up to participate in user research. 
+      <Link to={'/es/feedback/'}>
+        https://alpha.austin.gov/es/feedback/
+      </Link></p>
   </div>
 );
 

--- a/src/components/PageSections/PendingTranslation/index.js
+++ b/src/components/PageSections/PendingTranslation/index.js
@@ -12,8 +12,9 @@ const PendingTranslation = ({ open, intl }) => (
       'coa-PendingTranslation--is-open': open,
     })}
   >
-    <p>Translations for this website are a work in progress.</p>
-    <p className='coa-PendingTranslation--link'>If you would like to help us improve, please sign-up to participate in user research. 
+    <p>Continuamos trabajando y procesando las traducciones en este sitio web.</p>
+    <p className='coa-PendingTranslation--link'>
+      Si le gustaría ayudarnos a mejorar, por favor inscríbase para participar en nuestras investigaciones de usuarios 
       <Link to={'/es/feedback/'}>
         https://alpha.austin.gov/es/feedback/
       </Link></p>

--- a/src/components/PageSections/PendingTranslation/index.js
+++ b/src/components/PageSections/PendingTranslation/index.js
@@ -14,9 +14,9 @@ const PendingTranslation = ({ open, intl, closeMessage }) => (
   >
     <p>Continuamos trabajando y procesando las traducciones en este sitio web.</p>
     <p className='coa-PendingTranslation--link'>
-      Si le gustaría ayudarnos a mejorar, por favor inscríbase para participar en nuestras investigaciones de usuarios {' '}
+      Si le gustaría ayudarnos a mejorar, por favor inscríbase{' '}
       <Link to={'/es/feedback/'} onClick={closeMessage}>
-        https://alpha.austin.gov/es/feedback/
+        para participar en nuestras investigaciones de usuarios.
       </Link>
     </p>
   </div>

--- a/src/css/coa.scss
+++ b/src/css/coa.scss
@@ -62,3 +62,4 @@
 @import 'components/Pages/OfficialDocuments/_Pagination';
 @import 'components/Pages/Guide/Guide';
 @import 'components/Pages/Form';
+@import 'components/PageSections/PendingTranslation/PendingTranslation'

--- a/src/js/i18n/constants.js
+++ b/src/js/i18n/constants.js
@@ -12,6 +12,7 @@ export const SUPPORTED_LANGUAGES = [
     abbr: 'es',
     code: 'es',
     direction: 'ltr',
+    pending: true,
   },
   // {
   //   // Vietnamese


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

A Pending Translation component that appears when a user chooses Spanish. 

Because of how the header is laid out, in order to get the white background to match the xd, I created an empty div that is visible when the message is also visible. 


<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
Switch language to Spanish. Click around to close it, click the link, and navigate to other pages and see the dropdown doesnt reappear.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
