### PR TITLE
3518 Homepage tile fix

### DIFF
--- a/src/components/Pages/Home.js
+++ b/src/components/Pages/Home.js
@@ -16,7 +16,7 @@ const Home = ({ intl }) => {
   const { topServices, image } = useRouteData();
 
   return (
-    <div>
+    <div className="coa-HeroHome__container">
       <Head>
         <title>{'City of Austin'}</title>
       </Head>

--- a/src/components/Tiles/_TileGroup.scss
+++ b/src/components/Tiles/_TileGroup.scss
@@ -12,6 +12,14 @@
   }
 }
 
+// we need margin L/R auto on the homepage
+.coa-HeroHome__container {
+  .coa-TileGroup {
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
 .coa-TopicPage__tile-group {
   .coa-TileGroup {
     background: none;


### PR DESCRIPTION
https://github.com/cityofaustin/techstack/issues/3518

# Description
Gets the servies on the homepage properly centered again.

# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How can this be tested?
https://janis-3518-homepage-tiles.netlify.com/

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
