### PR TITLE
3429 Grid adjustment for information page content type

### DIFF
--- a/src/components/Pages/Information.js
+++ b/src/components/Pages/Information.js
@@ -59,7 +59,7 @@ const InformationPage = ({ informationPage, intl }) => {
           <div className="coa-Page__main-content">
             <div className="wrapper container-fluid">
               <div className="row">
-                <div className="col-xs-12 col-md-8">
+                <div className="col-xs-12 col-md-10">
                   {additionalContent && (
                     <HtmlFromAdmin title={' '} content={additionalContent} />
                   )}


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

The content of information pages is too narrow. Per Chase's direction, I changed it from `col-md-8` to `col-md-10`

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
