### PR TITLE
Justify Top Services tiles

### DIFF
--- a/src/components/Pages/_Department.scss
+++ b/src/components/Pages/_Department.scss
@@ -7,6 +7,11 @@
       font-size: $coa-font-size-md-small;
     }
   }
+
+  .coa-TileGroup {
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 .coa-DepartmentPage__topServiceButtons {


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Top Services on the homepage were justifying all the way to the left when they should be lined up with the global nav and feedback module. I did the same fix Brian did to the homepage.

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
