### PR TITLE
fixed a undefined bug in janis query

### DIFF
--- a/static.config.js
+++ b/static.config.js
@@ -343,7 +343,9 @@ const getServicePageData = async (
     client,
   );
 
-  service.pageIsPartOf = pagesOfGuides[id]
+  if (pagesOfGuides[id]) { // We're checking if this id is part of guide page because it may not be published and draw and error.
+    service.pageIsPartOf = pagesOfGuides[id]
+  }
 
   return { service: service };
 };
@@ -373,6 +375,10 @@ const getInformationPageData = async (
     informationPage.relatedDepartments,
     client,
   );
+
+  if (pagesOfGuides[id]) { // We're checking if this id is part of guide page because it may not be published and draw and error.
+    informationPage.pageIsPartOf = pagesOfGuides[id]
+  }
 
   informationPage.pageIsPartOf = pagesOfGuides[id]
 


### PR DESCRIPTION
# Description

I created this PR to fix a bug I created when we added Info and service pages as parts of guides UI. 
- What happens is that when we build our pagePartOfGuide object to check against when querying Info and service pages, we may find a page that is...
- part of an *unpublished* guide!

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

# Checklist:
- [x] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
