### PR TITLE
3387 related depts on preview

### DIFF
--- a/src/components/_Controllers/CMSPreview.js
+++ b/src/components/_Controllers/CMSPreview.js
@@ -165,7 +165,6 @@ class CMSPreview extends Component {
         <Route
           path="/services"
           render={props => <Service service={cleanServicesForPreview(data)} />}
-          // service page
         />
         <Route
           path="/information"

--- a/src/components/_Controllers/CMSPreview.js
+++ b/src/components/_Controllers/CMSPreview.js
@@ -165,6 +165,7 @@ class CMSPreview extends Component {
         <Route
           path="/services"
           render={props => <Service service={cleanServicesForPreview(data)} />}
+          // service page
         />
         <Route
           path="/information"

--- a/src/js/helpers/cleanData.js
+++ b/src/js/helpers/cleanData.js
@@ -323,7 +323,6 @@ export const cleanServicesForPreview = allServices => {
   if (!allServices || !allServices.edges) return null;
   const services = allServices.edges.map(e => e.node);
   let service = services[0];
-  // why do we get all the services to then just select the first one?
 
   service.contextualNavData = getContextualNavForPreview(service);
 

--- a/src/js/helpers/cleanData.js
+++ b/src/js/helpers/cleanData.js
@@ -325,7 +325,6 @@ export const cleanServicesForPreview = allServices => {
   let service = services[0];
   // why do we get all the services to then just select the first one?
 
-  console.log('service', service)
   service.contextualNavData = getContextualNavForPreview(service);
 
   service.text = service.title;

--- a/src/js/helpers/cleanData.js
+++ b/src/js/helpers/cleanData.js
@@ -323,7 +323,9 @@ export const cleanServicesForPreview = allServices => {
   if (!allServices || !allServices.edges) return null;
   const services = allServices.edges.map(e => e.node);
   let service = services[0];
+  // why do we get all the services to then just select the first one?
 
+  console.log('service', service)
   service.contextualNavData = getContextualNavForPreview(service);
 
   service.text = service.title;
@@ -369,6 +371,15 @@ const getContextualNavForPreview = page => {
     relatedTo: [],
     offeredBy: [],
   };
+
+  // get offered by
+  if (page.relatedDepartments && page.relatedDepartments.edges.length) {
+    contextualNavData.offeredBy = page.relatedDepartments.edges.map(edge => ({
+      id: edge.node.relatedDepartment.id,
+      title: edge.node.relatedDepartment.title,
+      url: `/${edge.node.relatedDepartment.slug}/`,
+    }));
+  }
 
   // If we don't have a topic, return a fake
   // topic describing that


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

We couldn't see the Related Departments information on previews (that shows up as Offered By). I added the code that handles it in the static.config to the cleanData function.

I also discovered that the "Related To" information also doesn't appear on previews, but that seems to be gathered from the overall site structure as far as I can tell. I couldnt quickly figure out if it was something that can be done on previews. 

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)



# How can this be tested?

https://janis-3387-related-depts.netlify.com/en/preview/information/UGFnZVJldmlzaW9uTm9kZToyMzk2?CMS_API=https://joplin-pr-3537-docs-rtf.herokuapp.com/api/graphql

https://joplin-pr-3537-docs-rtf.herokuapp.com/api/graphql for the joplin that will launch a preview here: https://janis-3387-related-depts.netlify.com

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [x] Link this PR in the issue
- [x] Moved card to *review* in zenhub
