### PR TITLE
fix topic pages to not link to draft pages

### DIFF
--- a/src/js/queries/getTopicPageQuery.js
+++ b/src/js/queries/getTopicPageQuery.js
@@ -41,6 +41,7 @@ const getTopicPageQuery = `
             id
             slug
             title
+            live
           }
         }
       }
@@ -52,6 +53,7 @@ const getTopicPageQuery = `
             id
             slug
             title
+            live
           }
         }
       }
@@ -63,6 +65,7 @@ const getTopicPageQuery = `
             id
             slug
             title
+            live
           }
         }
       }
@@ -75,6 +78,7 @@ const getTopicPageQuery = `
             slug
             title
             pageType
+            live
           }
         }
       }
@@ -86,6 +90,7 @@ const getTopicPageQuery = `
             id
             slug
             title
+            live
           }
         }
       }
@@ -97,6 +102,7 @@ const getTopicPageQuery = `
             id
             slug
             title
+            live
           }
         }
       }

--- a/static.config.js
+++ b/static.config.js
@@ -46,7 +46,9 @@ const getAllTopicLinks = (
   if (allServicePageTopics && allServicePageTopics.edges) {
     for (const edge of allServicePageTopics.edges) {
       if (edge.node) {
-        allLinks.push(edge.node.page);
+        if (edge.node.page.live) {
+          allLinks.push(edge.node.page);
+        }
       }
     }
   }
@@ -54,7 +56,9 @@ const getAllTopicLinks = (
   if (allInformationPageTopics && allInformationPageTopics.edges) {
     for (const edge of allInformationPageTopics.edges) {
       if (edge.node) {
-        allLinks.push(edge.node.page);
+        if (edge.node.page.live) {
+          allLinks.push(edge.node.page);
+        }
       }
     }
   }
@@ -62,7 +66,9 @@ const getAllTopicLinks = (
   if (allOfficialDocumentPageTopics && allOfficialDocumentPageTopics.edges) {
     for (const edge of allOfficialDocumentPageTopics.edges) {
       if (edge.node) {
-        allLinks.push(edge.node.page);
+        if (edge.node.page.live) {
+          allLinks.push(edge.node.page);
+        }
       }
     }
   }
@@ -70,7 +76,9 @@ const getAllTopicLinks = (
   if (allGuidePageTopics && allGuidePageTopics.edges) {
     for (const edge of allGuidePageTopics.edges) {
       if (edge.node) {
-        allLinks.push(edge.node.page);
+        if (edge.node.page.live) {
+          allLinks.push(edge.node.page);
+        }
       }
     }
   }
@@ -78,7 +86,9 @@ const getAllTopicLinks = (
   if (allFormContainerTopics && allFormContainerTopics.edges) {
     for (const edge of allFormContainerTopics.edges) {
       if (edge.node) {
-        allLinks.push(edge.node.page);
+        if (edge.node.page.live) {
+          allLinks.push(edge.node.page);
+        }
       }
     }
   }


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Draft pages were showing up as links on topic pages. This doesn't fix the fact that the drafts are still being published at urls, but does fix the issue of them showing up as links on topic pages.

https://github.com/cityofaustin/techstack/issues/3689

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
1. Go here: https://alpha.austin.gov/en/health-safety/healthcare-prevention/kids-and-family-resources
2. see 2 'WIC Benefits' links
3. Go here: https://janis-3689-links-to-drafts.netlify.com/en/health-safety/healthcare-prevention/kids-and-family-resources
4. see 1 'WIC Benefits' link

# Checklist:
- [x] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
