### PR TITLE
3720 location page related services

### DIFF
--- a/src/components/Pages/Location/LocationServiceList.js
+++ b/src/components/Pages/Location/LocationServiceList.js
@@ -81,12 +81,11 @@ const Service = ({ service }) => {
     <div className="coa-LocationPage__service-container">
       <div className="coa-LocationPage__service-title">{service.title}</div>
       <div className="coa-LocationPage__service-info-container">
-        <div className="coa-LocationPage__service-phone-container">
-          <table className="coa-LocationPage__table">
-            <tbody>
-              {!!service.phones &&
-                !!service.phones.length &&
-                service.phones.map(phone => (
+        {!!service.phones && !!service.phones.length && (
+          <div className="coa-LocationPage__service-phone-container">
+            <table className="coa-LocationPage__table">
+              <tbody>
+                {service.phones.map(phone => (
                   <tr>
                     {!!phone.label && (
                       <td className="coa-LocationPage__table-service-label">
@@ -98,9 +97,10 @@ const Service = ({ service }) => {
                     </td>
                   </tr>
                 ))}
-            </tbody>
-          </table>
-        </div>
+              </tbody>
+            </table>
+          </div>
+        )}
         {Object.values(service.hours).some(x => x !== null) && (
           <ServiceHours hours={service.hours} />
         )}

--- a/src/js/helpers/cleanData.js
+++ b/src/js/helpers/cleanData.js
@@ -82,7 +82,8 @@ export const cleanContacts = contacts => {
 
 export const cleanLocationPageJanisUrl = janisUrl => {
   // quick fix for urls until we get localized urls working in joplin
-  return janisUrl.split('en')[1];
+
+  return janisUrl.split('/en/')[1];
 };
 
 export const cleanLocationPageHours = locationPage => {

--- a/src/js/helpers/cleanData.js
+++ b/src/js/helpers/cleanData.js
@@ -82,8 +82,7 @@ export const cleanContacts = contacts => {
 
 export const cleanLocationPageJanisUrl = janisUrl => {
   // quick fix for urls until we get localized urls working in joplin
-
-  return janisUrl.split('/en/')[1];
+  return `/${janisUrl.split('/en/')[1]}`;
 };
 
 export const cleanLocationPageHours = locationPage => {


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

https://github.com/cityofaustin/techstack/issues/3720

Test by checking https://janis.austintexas.io/en/location/faulk/ vs https://janis-3720-location-page-related-services.netlify.com/en/location/faulk/

Fixes:
* Broken location page related service urls
* Blank divs on location page related services without phone number info

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
- [x] Request reviewers
- [x] Slack-out message for review
- [x] Link this PR in the issue
- [x] Moved card to *review* in zenhub
