### PR TITLE
filter out non live topic pages

### DIFF
--- a/src/js/queries/getTopicCollectionPageQuery.js
+++ b/src/js/queries/getTopicCollectionPageQuery.js
@@ -20,6 +20,7 @@ const getTopicCollectionPageQuery = `
         node {
           page {
             id
+            live
             slug
             title
             description

--- a/static.config.js
+++ b/static.config.js
@@ -211,24 +211,26 @@ const getTopicCollectionPageData = async (id, client) => {
   } = await client.request(getTopicCollectionPageQuery, { id: id });
 
   let topicCollection = allTopicCollections.edges[0].node;
-  topicCollection.topics = allTopicPageTopicCollections.edges.map(edge => ({
-    title: edge.node.page.title,
-    description: edge.node.page.description,
-    slug: edge.node.page.slug,
-    topiccollection: {
-      slug: topicCollection.slug,
-      theme: {
-        slug: topicCollection.theme.slug,
+  topicCollection.topics = allTopicPageTopicCollections.edges
+    .filter(edge => edge.node.page.live)
+    .map(edge => ({
+      title: edge.node.page.title,
+      description: edge.node.page.description,
+      slug: edge.node.page.slug,
+      topiccollection: {
+        slug: topicCollection.slug,
+        theme: {
+          slug: topicCollection.theme.slug,
+        },
       },
-    },
-    pages: edge.node.page.topPages.edges.map(topPageEdge => ({
-      pageType: topPageEdge.node.pageType,
-      title: topPageEdge.node.title,
-      url: `/${topicCollection.theme.slug}/${topicCollection.slug}/${
-        edge.node.page.slug
-      }/${topPageEdge.node.slug}/`,
-    })),
-  }));
+      pages: edge.node.page.topPages.edges.map(topPageEdge => ({
+        pageType: topPageEdge.node.pageType,
+        title: topPageEdge.node.title,
+        url: `/${topicCollection.theme.slug}/${topicCollection.slug}/${
+          edge.node.page.slug
+        }/${topPageEdge.node.slug}/`,
+      })),
+    }));
 
   return { tc: topicCollection };
 };


### PR DESCRIPTION
what this does:
https://github.com/cityofaustin/techstack/issues/3712
makes it so we don't make topic cards for non live topic pages
what this doesn't:
prevent non live topic pages from publishing out at a url