### PR TITLE
doing this the dumb way

### DIFF
--- a/src/components/PageSections/Footer/index.js
+++ b/src/components/PageSections/Footer/index.js
@@ -7,7 +7,6 @@ import { misc as i18n } from 'js/i18n/definitions';
 import FormFeedback from 'components/FormFeedback';
 import ExternalLink from 'components/ExternalLink';
 import WorkInProgress from 'components/WorkInProgress';
-import UserFeedback from 'components/UserFeedback';
 
 import TwitterSVG from 'components/SVGs/Twitter';
 import FacebookSVG from 'components/SVGs/Facebook';
@@ -29,7 +28,7 @@ import { Link } from 'react-router-dom';
 
 const Footer = ({ intl }) => (
   <footer>
-    <UserFeedback />
+
     <div className="coa-Footer">
       <FooterSiteMap />
       <div className="coa-Footer__city-seal-wrapper">

--- a/src/components/Pages/Departments.js
+++ b/src/components/Pages/Departments.js
@@ -22,6 +22,7 @@ const Departments = ({ intl }) => {
       <div className="wrapper container-fluid">
         <TileGroup tiles={departments} />
       </div>
+      <UserFeedback />
     </div>
   );
 };

--- a/src/components/Pages/Departments.js
+++ b/src/components/Pages/Departments.js
@@ -9,6 +9,7 @@ import PageBreadcrumbs from 'components/PageBreadcrumbs';
 import PageHeader from 'components/PageHeader';
 import SectionHeader from 'components/SectionHeader';
 import TileGroup from 'components/Tiles/TileGroup';
+import UserFeedback from 'components/UserFeedback';
 
 const Departments = ({ intl }) => {
   const { departments } = useRouteData();

--- a/src/components/Pages/Guide/index.js
+++ b/src/components/Pages/Guide/index.js
@@ -17,6 +17,7 @@ import { printSections } from 'components/Pages/Guide/helpers.js';
 import { hyphenate } from './helpers';
 
 import guidePagePlaceholder from 'images/guide_page_placeholder.png';
+import UserFeedback from 'components/UserFeedback';
 
 function Guide({ guidePage, intl }) {
   const {
@@ -292,6 +293,7 @@ function Guide({ guidePage, intl }) {
           </div>
         </div>
       </div>
+      <UserFeedback />
     </div>
   );
 }

--- a/src/components/Pages/Home.js
+++ b/src/components/Pages/Home.js
@@ -9,6 +9,7 @@ import PageNotificationBanner from 'components/PageNotificationBanner';
 import HeroHome from 'components/HeroHome';
 import ExternalLink from 'components/ExternalLink';
 import SectionHeader from 'components/SectionHeader';
+import UserFeedback from 'components/UserFeedback';
 
 import TileGroup from 'components/Tiles/TileGroup';
 
@@ -31,10 +32,13 @@ const Home = ({ intl }) => {
         title={intl.formatMessage(i18n3.checkOutServices)}
         tiles={topServices}
       />
+
+
       {/* We are leaving it here because we might need it again.*/}
       {/*<PageNotificationBanner>*/}
       {/*  <WorkInProgress />*/}
       {/*</PageNotificationBanner>*/}
+      <UserFeedback />
     </div>
   );
 };

--- a/src/components/Pages/Information.js
+++ b/src/components/Pages/Information.js
@@ -16,6 +16,7 @@ import SectionHeader from 'components/SectionHeader';
 import ContextualNav from 'components/PageSections/ContextualNav';
 import RelatedToMobile from '../PageSections/ContextualNav/RelatedToMobile';
 import PageIsPartOfContainer from 'components/PageSections/PageIsPartOfContainer';
+import UserFeedback from 'components/UserFeedback';
 
 const InformationPage = ({ informationPage, intl }) => {
   const {
@@ -101,6 +102,7 @@ const InformationPage = ({ informationPage, intl }) => {
           />
         )}
       </div>
+      <UserFeedback />
     </div>
   );
 };

--- a/src/components/Pages/Location/index.js
+++ b/src/components/Pages/Location/index.js
@@ -5,6 +5,7 @@ import PageHeader from 'components/PageHeader';
 import LocationInfo from 'components/Pages/Location/LocationInfo';
 import LocationServiceList from 'components/Pages/Location/LocationServiceList';
 import LocationGettingHere from 'components/Pages/Location/LocationGettingHere';
+import UserFeedback from 'components/UserFeedback';
 
 import 'components/Pages/Location/_Location.scss';
 
@@ -43,6 +44,7 @@ const LocationPage = ({ locationPage }) => {
         )}
         {!!buses && !!buses.length && <LocationGettingHere buses={buses} />}
       </div>
+      <UserFeedback />
     </div>
   );
 };

--- a/src/components/Pages/OfficialDocuments/OfficialDocument.js
+++ b/src/components/Pages/OfficialDocuments/OfficialDocument.js
@@ -4,6 +4,7 @@ import { injectIntl } from 'react-intl';
 import moment from 'moment-timezone';
 
 import { officialdocuments as i18n } from 'js/i18n/definitions';
+import UserFeedback from 'components/UserFeedback';
 
 const OfficialDocument = ({ document: { id, date, title, authoringOffice, summary, name, link, pdfSize }, intl }) => {
   // If the link is a PDF with a pdfSize, then include it.
@@ -27,6 +28,7 @@ const OfficialDocument = ({ document: { id, date, title, authoringOffice, summar
       <div className="coa-OfficialDocumentPage__small-heading-container">
         <span className="coa-OfficialDocumentPage__small-heading">{intl.formatMessage(i18n.document)}:</span> <a href={link}>{name}</a> {pdfComponent}
       </div>
+      <UserFeedback />
     </div>
   );
 }

--- a/src/components/Pages/Service.js
+++ b/src/components/Pages/Service.js
@@ -15,6 +15,7 @@ import SectionHeader from 'components/SectionHeader';
 import ContextualNav from '../PageSections/ContextualNav';
 import RelatedToMobile from '../PageSections/ContextualNav/RelatedToMobile';
 import PageIsPartOfContainer from 'components/PageSections/PageIsPartOfContainer';
+import UserFeedback from 'components/UserFeedback';
 
 const Service = ({ service, intl }) => {
   const {
@@ -114,6 +115,7 @@ const Service = ({ service, intl }) => {
           offeredBy={contextualNavData.offeredBy}
         />
       </div>
+      <UserFeedback />
     </div>
   );
 };

--- a/src/components/Pages/Topic.js
+++ b/src/components/Pages/Topic.js
@@ -11,6 +11,7 @@ import SectionHeader from 'components/SectionHeader';
 import TileGroup from 'components/Tiles/TileGroup';
 import ContextualNav from '../PageSections/ContextualNav';
 import RelatedToMobile from '../PageSections/ContextualNav/RelatedToMobile';
+import UserFeedback from 'components/UserFeedback';
 
 const Topic = ({ topic, intl }) => {
   const {
@@ -59,6 +60,7 @@ const Topic = ({ topic, intl }) => {
         </div>
       </div>
       <RelatedToMobile relatedTo={contextualNavData.relatedTo} offeredBy={[]} />
+      <UserFeedback />
     </Fragment>
   );
 };

--- a/src/components/Pages/TopicCollection.js
+++ b/src/components/Pages/TopicCollection.js
@@ -8,6 +8,7 @@ import { topics as i18n } from 'js/i18n/definitions';
 import PageHeader from 'components/PageHeader';
 import ContextualNav from '../PageSections/ContextualNav';
 import TopicCollectionCards from '../PageSections/TopicCollectionCards';
+import UserFeedback from 'components/UserFeedback';
 
 const TopicCollection = ({ tc, intl }) => {
   const {
@@ -32,15 +33,16 @@ const TopicCollection = ({ tc, intl }) => {
           </div>
         </div>
       </div>
+      <UserFeedback />
     </div>
   );
 };
 
 TopicCollection.propTypes = {
-  title:PropTypes.string, 
-  description:PropTypes.string, 
-  theme:PropTypes.string, 
-  topics:PropTypes.array, 
+  title:PropTypes.string,
+  description:PropTypes.string,
+  theme:PropTypes.string,
+  topics:PropTypes.array,
   slug:PropTypes.string,
 }
 


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description
This moves the UserFeedback component out of the footer and into each page. 

Ideally we'd have a smarter way to implement and conditionally include components on a page. But perhaps being verbose but explicit is better? 

Eventually stuff like https://github.com/cityofaustin/techstack/issues/3717 is going to require us to be smarter

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
   <!--- Netlify Example: `https://janis-<PR>.netlify.com/` --->  

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
