### PR TITLE
Don't hide "get a resume link" page in form iframe

### DIFF
--- a/src/components/Pages/Form.js
+++ b/src/components/Pages/Form.js
@@ -7,7 +7,7 @@ import { injectIntl } from 'react-intl';
   On Framestack, this is done by modifying the html in the "Advanced Code Editor" of your custom template.
   See: https://github.com/davidjbradshaw/iframe-resizer
 **/
-import IframeResizer from 'iframe-resizer-react'
+import IframeResizer from 'iframe-resizer-react';
 import { misc as i18n2, services as i18n3 } from 'js/i18n/definitions';
 
 import PageHeader from 'components/PageHeader';
@@ -39,15 +39,15 @@ function FormContainer({
   // Go to the top of the page when we transition to the form Confirmation Page.
   // "init" events after the first "init" means that there was a page transition within the iframe.
   let iframeLoaded = false;
-  const onResized = ({iframe, height, width, type}) => {
-    if (type === "init") {
+  const onResized = ({ iframe, height, width, type }) => {
+    if (type === 'init') {
       if (iframeLoaded) {
-        document.getElementById("coa-FormContainer__top").scrollIntoView(true);
+        document.getElementById('coa-FormContainer__top').scrollIntoView(true);
       } else {
         iframeLoaded = true;
       }
     }
-  }
+  };
 
   return (
     <div>
@@ -73,7 +73,7 @@ function FormContainer({
                   forwardRef={iframeRef}
                   src={formUrl}
                   className="coa-FormContainer__IframeResizer-default"
-                  heightCalculationMethod="taggedElement"
+                  heightCalculationMethod="lowestElement"
                   frameBorder="0"
                   onResized={onResized}
                 />


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Since we don't have the ability to tag elements on the new page where the link is generated, we need to get the lowest of all elements instead of the lowest tagged element

https://github.com/cityofaustin/techstack/issues/3773

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
https://janis-3773-dont-blank-form.netlify.com/en/preview/form/UGFnZVJldmlzaW9uTm9kZToyODg3
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
   <!--- Netlify Example: `https://janis-<PR>.netlify.com/` --->  

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
