### PR TITLE
3840 Locations hours display

### DIFF
--- a/src/components/Pages/Location/LocationInfo.js
+++ b/src/components/Pages/Location/LocationInfo.js
@@ -148,15 +148,10 @@ const LocationPageFacilityHours = ({ hours }) => {
     </div>
   );
 
-  // ⏰ ⏰ ⏰ ⏰ ⏰ ⏰
-  // ⏰ ⏰ ⏰ ⏰ ⏰ ⏰
-  // ⏰ ⏰ ⏰ ⏰ ⏰ ⏰
-  // ⏰ ⏰ ⏰ ⏰ ⏰ ⏰
-
   return (
     <div className="coa-LocationPage__sub-section">
       <h2 className="coa-LocationPage__sub-section-title">
-        ⏰{intl.formatMessage(i18nLocations.facilityHours)}
+        {intl.formatMessage(i18nLocations.facilityHours)}
       </h2>
       <div className="coa-LocationPage__sub-section-block-container">
         <LocationPageBlock
@@ -164,12 +159,6 @@ const LocationPageFacilityHours = ({ hours }) => {
           content={HoursText}
         />
         {!!hours.exceptions && (
-          // <LocationPageBlock
-          //   title={intl.formatMessage(i18nContact.exceptions)}
-          //   content={hours.exceptions}
-          // />
-          //
-          //
           <div className="coa-LocationPage__sub-section-block">
             <div className="coa-LocationPage__sub-section-block-title-padded">
               {intl.formatMessage(i18nContact.exceptions)}
@@ -178,15 +167,11 @@ const LocationPageFacilityHours = ({ hours }) => {
               {hours.exceptions}
             </div>
           </div>
-          //
-          //
         )}
       </div>
     </div>
   );
 };
-
-
 
 const LocationPageInfo = ({ phone, email, location, image, hours }) => (
   <div className="coa-LocationPage__section">

--- a/src/components/Pages/Location/LocationInfo.js
+++ b/src/components/Pages/Location/LocationInfo.js
@@ -141,10 +141,18 @@ const LocationPageFacilityHours = ({ hours }) => {
     </div>
   );
 
+  // ⏰ ⏰ ⏰ ⏰ ⏰ ⏰
+  // ⏰ ⏰ ⏰ ⏰ ⏰ ⏰
+  // ⏰ ⏰ ⏰ ⏰ ⏰ ⏰
+  // ⏰ ⏰ ⏰ ⏰ ⏰ ⏰
+  // const Testy = (
+  //
+  // )
+
   return (
     <div className="coa-LocationPage__sub-section">
       <h2 className="coa-LocationPage__sub-section-title">
-        {intl.formatMessage(i18nLocations.facilityHours)}
+        ⏰{intl.formatMessage(i18nLocations.facilityHours)}
       </h2>
       <div className="coa-LocationPage__sub-section-block-container">
         <LocationPageBlock
@@ -152,15 +160,27 @@ const LocationPageFacilityHours = ({ hours }) => {
           content={HoursText}
         />
         {!!hours.exceptions && (
-          <LocationPageBlock
-            title={intl.formatMessage(i18nContact.exceptions)}
-            content={hours.exceptions}
-          />
+          // <LocationPageBlock
+          //   title={intl.formatMessage(i18nContact.exceptions)}
+          //   content={{hours.exceptions}</h2>)}
+          // />
+          <div className="coa-LocationPage__sub-section-block">
+            <div className="coa-LocationPage__sub-section-block-title">
+              <div>
+                {intl.formatMessage(i18nContact.exceptions)}
+              </div>
+            </div>
+            <div className="coa-LocationPage__sub-section-block-contents">
+              {hours.exceptions}
+            </div>
+          </div>
         )}
       </div>
     </div>
   );
 };
+
+
 
 const LocationPageInfo = ({ phone, email, location, image, hours }) => (
   <div className="coa-LocationPage__section">

--- a/src/components/Pages/Location/LocationInfo.js
+++ b/src/components/Pages/Location/LocationInfo.js
@@ -131,7 +131,14 @@ const LocationPageFacilityHours = ({ hours }) => {
               </td>
               <td>
                 {hours[day] !== null
-                  ? hours[day]
+                  ? hours[day].split(',').map( (dateRange, i) => {
+                    const comma = i+1 < hours[day].split(',').length ? "," : ""
+                    return (
+                      <div class="coa-LocationPage__hours-section">
+                        {dateRange}{comma}&nbsp;
+                      </div>
+                    )
+                  })
                   : intl.formatMessage(i18nLocations.closed)}
               </td>
             </tr>
@@ -145,9 +152,6 @@ const LocationPageFacilityHours = ({ hours }) => {
   // ⏰ ⏰ ⏰ ⏰ ⏰ ⏰
   // ⏰ ⏰ ⏰ ⏰ ⏰ ⏰
   // ⏰ ⏰ ⏰ ⏰ ⏰ ⏰
-  // const Testy = (
-  //
-  // )
 
   return (
     <div className="coa-LocationPage__sub-section">
@@ -162,18 +166,20 @@ const LocationPageFacilityHours = ({ hours }) => {
         {!!hours.exceptions && (
           // <LocationPageBlock
           //   title={intl.formatMessage(i18nContact.exceptions)}
-          //   content={{hours.exceptions}</h2>)}
+          //   content={hours.exceptions}
           // />
+          //
+          //
           <div className="coa-LocationPage__sub-section-block">
-            <div className="coa-LocationPage__sub-section-block-title">
-              <div>
-                {intl.formatMessage(i18nContact.exceptions)}
-              </div>
+            <div className="coa-LocationPage__sub-section-block-title-padded">
+              {intl.formatMessage(i18nContact.exceptions)}
             </div>
             <div className="coa-LocationPage__sub-section-block-contents">
               {hours.exceptions}
             </div>
           </div>
+          //
+          //
         )}
       </div>
     </div>

--- a/src/components/Pages/Location/_Location.scss
+++ b/src/components/Pages/Location/_Location.scss
@@ -104,6 +104,11 @@ $coa-location-page-section-background: #f7f7f7;
   font-weight: bolder;
 }
 
+.coa-LocationPage__sub-section-block-title-padded {
+  font-weight: bolder;
+  padding-bottom: 1.5rem;
+}
+
 .coa-LocationPage__address-line {
   display: block;
 }
@@ -119,6 +124,7 @@ $coa-location-page-section-background: #f7f7f7;
 
 .coa-LocationPage__table {
   margin: 0;
+  margin-bottom: 1.5rem;
   td {
     background-color: inherit;
     border: none;
@@ -126,11 +132,17 @@ $coa-location-page-section-background: #f7f7f7;
     padding: 0 1rem 0 0;
     font-size: 1.7rem;
     line-height: 2.4rem;
+    vertical-align: top;
+    padding-bottom: 0.5rem;
 
     // &:not(:last-child) {
     //   padding-top: .5rem;
     // }
   }
+}
+
+.coa-LocationPage__hours-section {
+  display: inline-block;
 }
 
 .coa-LocationPage__service-container {

--- a/src/components/Pages/Location/_Location.scss
+++ b/src/components/Pages/Location/_Location.scss
@@ -69,7 +69,8 @@ $coa-location-page-section-background: #f7f7f7;
 
 .coa-LocationPage__sub-section-block-container {
   display: flex;
-  flex-direction: row;
+  // flex-direction: row;
+  flex-direction: column;
   @include mobile {
     flex-direction: column;
   }

--- a/src/components/Pages/Location/_Location.scss
+++ b/src/components/Pages/Location/_Location.scss
@@ -69,7 +69,6 @@ $coa-location-page-section-background: #f7f7f7;
 
 .coa-LocationPage__sub-section-block-container {
   display: flex;
-  // flex-direction: row;
   flex-direction: column;
   @include mobile {
     flex-direction: column;

--- a/src/components/Pages/Location/index.js
+++ b/src/components/Pages/Location/index.js
@@ -22,8 +22,6 @@ const LocationPage = ({ locationPage }) => {
     },
   } = locationPage ? { locationPage } : useRouteData();
 
-  console.log("hours :", hours)
-
   return (
     <div>
       <Head>

--- a/src/components/Pages/Location/index.js
+++ b/src/components/Pages/Location/index.js
@@ -22,6 +22,8 @@ const LocationPage = ({ locationPage }) => {
     },
   } = locationPage ? { locationPage } : useRouteData();
 
+  console.log("hours :", hours)
+
   return (
     <div>
       <Head>


### PR DESCRIPTION
Zenhub Link: https://app.zenhub.com/workspaces/techstack-5a78b88e1ce69f3510b678ef/issues/cityofaustin/techstack/3840

# Description

This PR will add design and width brackdown for your locations components. See ☝️issue link above for design. 

@briaguya and @Niicck you both built this out initially - So, I did my best to stick with our html and css patter here. However, you may catch something that could be organized better. 

# Types of changes
- [x] New feature (non-breaking change which adds functionality)

# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
Deployed: https://janis-3840-location-hours.netlify.com/
- Mixed Example:  https://janis-3840-location-hours.netlify.com/en/location/st-john-neighborhood-center/
- Simple Example:  https://janis-3840-location-hours.netlify.com/en/location/recycle-reuse-drop-off-center/

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
