### PR TITLE
Window build fix error

### DIFF
--- a/src/components/Pages/Form.js
+++ b/src/components/Pages/Form.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { withRouteData, Head } from 'react-static';
 import { injectIntl } from 'react-intl';
 /**
@@ -60,13 +60,14 @@ function FormContainer({
     }
   },5000)
 
-
-  loader.start({
-    contentId: 'coa-iFrameForm',
-    loaderId: 'coa-loadingWheel',
-    errorId: 'coa-LockedIframeRequestMessage',
-    style: "popup"
-  })
+  useEffect(() => {
+    loader.start({
+      contentId: 'coa-iFrameForm',
+      loaderId: 'coa-loadingWheel',
+      errorId: 'coa-LockedIframeRequestMessage',
+      style: "popup"
+    })
+  }, []) // By having the second argument as an empty string, it will act as "ComponentDidMount" and execute once the component's elements have been added to the dom.
 
   return (
     <div>

--- a/src/js/animations/loader.js
+++ b/src/js/animations/loader.js
@@ -27,11 +27,11 @@ export const loader = {
 
 
   setValues: function(){
-    window.requestAnimationFrame(()=>{
-    // setTimeout(()=>{
+    setTimeout(()=>{
       /*
-        This "window.requestAnimationFrame" waits until react components have
-        been added to the dom - so we can "grab" them by their Id here.
+        This 1ms timeout allows the react components to have
+        been added to the dom - so we can "grab" them by their Id here. 
+        - Note: the process must complete before the timeout is checked, even if more then 1ms.
       */
       this.content = document.getElementById(this.contentId)
       this.loader = document.getElementById(this.loaderId)
@@ -56,8 +56,7 @@ export const loader = {
       this.error.style.opacity = 0
       this.error.style.transition = "opacity "+delay+"s, margin-top "+delay+"s"
 
-    })
-    // },1)
+    },1)
   },
 
 

--- a/src/js/animations/loader.js
+++ b/src/js/animations/loader.js
@@ -27,36 +27,28 @@ export const loader = {
 
 
   setValues: function(){
-    setTimeout(()=>{
-      /*
-        This 1ms timeout allows the react components to have
-        been added to the dom - so we can "grab" them by their Id here. 
-        - Note: the process must complete before the timeout is checked, even if more then 1ms.
-      */
-      this.content = document.getElementById(this.contentId)
-      this.loader = document.getElementById(this.loaderId)
+    this.content = document.getElementById(this.contentId)
+    this.loader = document.getElementById(this.loaderId)
 
-      if (this.errorId) {
-        this.error = document.getElementById(this.errorId)
-        this.error.style.opacity = 0
-      }
-
-      if (this.style === "popup") {
-        this.contentMarginTop = this.content.style.marginTop
-      }
-
-      const delay = this.delay / 1000
-
-      this.loader.style.opacity = 0
-      this.loader.style.transition = "opacity "+delay+"s"
-
-      this.content.style.opacity = 0
-      this.content.style.transition = "opacity "+delay+"s, margin-top "+delay+"s"
-
+    if (this.errorId) {
+      this.error = document.getElementById(this.errorId)
       this.error.style.opacity = 0
-      this.error.style.transition = "opacity "+delay+"s, margin-top "+delay+"s"
+    }
 
-    },1)
+    if (this.style === "popup") {
+      this.contentMarginTop = this.content.style.marginTop
+    }
+
+    const delay = this.delay / 1000
+
+    this.loader.style.opacity = 0
+    this.loader.style.transition = "opacity "+delay+"s"
+
+    this.content.style.opacity = 0
+    this.content.style.transition = "opacity "+delay+"s, margin-top "+delay+"s"
+
+    this.error.style.opacity = 0
+    this.error.style.transition = "opacity "+delay+"s, margin-top "+delay+"s"
   },
 
 

--- a/src/js/animations/loader.js
+++ b/src/js/animations/loader.js
@@ -27,7 +27,8 @@ export const loader = {
 
 
   setValues: function(){
-    window.requestAnimationFrame(()=>{
+    // window.requestAnimationFrame(()=>{
+    setTimeout(()=>{
       /*
         This "window.requestAnimationFrame" waits until react components have
         been added to the dom - so we can "grab" them by their Id here.
@@ -55,7 +56,8 @@ export const loader = {
       this.error.style.opacity = 0
       this.error.style.transition = "opacity "+delay+"s, margin-top "+delay+"s"
 
-    })
+    // })
+    },1000)
   },
 
 

--- a/src/js/animations/loader.js
+++ b/src/js/animations/loader.js
@@ -27,8 +27,8 @@ export const loader = {
 
 
   setValues: function(){
-    // window.requestAnimationFrame(()=>{
-    setTimeout(()=>{
+    window.requestAnimationFrame(()=>{
+    // setTimeout(()=>{
       /*
         This "window.requestAnimationFrame" waits until react components have
         been added to the dom - so we can "grab" them by their Id here.
@@ -56,8 +56,8 @@ export const loader = {
       this.error.style.opacity = 0
       this.error.style.transition = "opacity "+delay+"s, margin-top "+delay+"s"
 
-    // })
-    },1000)
+    })
+    // },1)
   },
 
 


### PR DESCRIPTION
This fix looks at the recent build fails in our pipeline. Once again, I've re-discovered that `window` during builds doesn't exist, so it fails. 

But, that's ok, because react hooks can come to the rescue!

I figured out a way to use hooks without a variable. Pretty much, this will act as an event that fires when the component has been added to the dom. allowing you to do fun stuff with js!

```javascript
  useEffect(() => {
    // you can now do stuff with your components html!
  }, [])
```
