### PR TITLE
3818 events view on the homepage

### DIFF
--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -32,7 +32,7 @@ const branchOverrides = {
     CMS_API: "https://joplin-pr-3202-form.herokuapp.com/api/graphql"
   },
   '3818-event-home': {
-    CMS_API: 'https://joplin-pr-3818-event-home.herokuapp.com/api/graphql'
+    CMS_API: 'https://joplin-pr-3818-event-home2.herokuapp.com/api/graphql'
   },
   '3244-guide-icon-tiles': {
     CMS_API: 'https://joplin-pr-3244-guide-icon-tile.herokuapp.com/api/graphql'

--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -31,8 +31,8 @@ const branchOverrides = {
   "3202-form": {
     CMS_API: "https://joplin-pr-3202-form.herokuapp.com/api/graphql"
   },
-  '3219-en-dash-contacts': {
-    CMS_API: 'https://joplin-pr-3163-guide-pages.herokuapp.com/api/graphql'
+  '3818-event-home': {
+    CMS_API: 'https://joplin-pr-3818-event-home.herokuapp.com/api/graphql'
   },
   '3244-guide-icon-tiles': {
     CMS_API: 'https://joplin-pr-3244-guide-icon-tile.herokuapp.com/api/graphql'

--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -31,9 +31,6 @@ const branchOverrides = {
   "3202-form": {
     CMS_API: "https://joplin-pr-3202-form.herokuapp.com/api/graphql"
   },
-  '3818-event-home': {
-    CMS_API: 'https://joplin-pr-3818-event-home2.herokuapp.com/api/graphql'
-  },
   '3244-guide-icon-tiles': {
     CMS_API: 'https://joplin-pr-3244-guide-icon-tile.herokuapp.com/api/graphql'
   },

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "start-local": "./scripts/serve-local.sh",
     "start-joplin-prod": "NODE_PATH=./src CMS_API='http://joplin.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='https://joplin-austin-gov-static.s3.amazonaws.com/production/media/documents' npm-run-all -p watch-css start-js",
     "start-joplin-staging": "NODE_PATH=./src CMS_API='http://joplin-staging.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='multiple' npm-run-all -p watch-css start-js",
-    "start-joplin-pr": "NODE_PATH=./src CMS_API='http://joplin-pr-3818-event-home.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='multiple' npm-run-all -p watch-css start-js",
+    "start-joplin-pr": "NODE_PATH=./src CMS_API='http://joplin-pr-3818-event-home2.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='multiple' npm-run-all -p watch-css start-js",
     "start-joplin-local": "NODE_PATH=./src CMS_API='http://localhost:8000/api/graphql' CMS_MEDIA='http://localhost:8000/media' CMS_DOCS='multiple' npm-run-all -p watch-css start-js",
     "start-staging": "./scripts/serve-local.sh -S",
     "start-prod": "./scripts/serve-local.sh -P",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "start-local": "./scripts/serve-local.sh",
     "start-joplin-prod": "NODE_PATH=./src CMS_API='http://joplin.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='https://joplin-austin-gov-static.s3.amazonaws.com/production/media/documents' npm-run-all -p watch-css start-js",
     "start-joplin-staging": "NODE_PATH=./src CMS_API='http://joplin-staging.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='multiple' npm-run-all -p watch-css start-js",
-    "start-joplin-pr": "NODE_PATH=./src CMS_API='http://joplin-pr-3817-event-lists.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='multiple' npm-run-all -p watch-css start-js",
+    "start-joplin-pr": "NODE_PATH=./src CMS_API='http://joplin-pr-3818-event-home.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='multiple' npm-run-all -p watch-css start-js",
     "start-joplin-local": "NODE_PATH=./src CMS_API='http://localhost:8000/api/graphql' CMS_MEDIA='http://localhost:8000/media' CMS_DOCS='multiple' npm-run-all -p watch-css start-js",
     "start-staging": "./scripts/serve-local.sh -S",
     "start-prod": "./scripts/serve-local.sh -P",

--- a/src/components/PageHeader/_PageHeader.scss
+++ b/src/components/PageHeader/_PageHeader.scss
@@ -80,6 +80,22 @@
 
 .coa-PageHeader--event-list {
   background-color: #f7f9fa;
-  padding-bottom: 80px;
+  padding-bottom: 40px;
+  padding-top: 40px;
   padding-left: 10px;
+  margin: auto;
+  @include media($coa-medium-screen) {
+    padding-bottom: 80px;
+    padding-top: 80px;
+    margin: unset;
+  }
+}
+
+.coa-PageHeader--event-list {
+  h1 {
+    text-align: center;
+    @include media($coa-medium-screen) {
+      text-align: left;
+    }
+  }
 }

--- a/src/components/PageSections/EventsHomePage/_EventsHomePage.scss
+++ b/src/components/PageSections/EventsHomePage/_EventsHomePage.scss
@@ -24,7 +24,7 @@
 }
 
 .coa-EventsHomePage__allEventsButton {
-  width: 314px;
+  width: 280px;
   height: 48px;
   text-decoration: none;
   display: block;
@@ -43,7 +43,7 @@
   color: #FFFFFF;
   padding-top: 14px;
   line-height: 20px;
-  width: 314px;
+  width: 280px;
   height: 48px;
   background-color: #0050D8;
   border-radius: 4px;

--- a/src/components/PageSections/EventsHomePage/_EventsHomePage.scss
+++ b/src/components/PageSections/EventsHomePage/_EventsHomePage.scss
@@ -1,0 +1,20 @@
+.coa-EventsHomePage__container {
+  padding: $coa-spacing-large $coa-spacing-medium;
+  max-width: $coa-wrapper-maxwidth;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.coa-EventsHomePage__allEventsButton {
+  height: 48px;
+  width: 260px;
+  background-color: #0050D8;
+  a {
+    text-decoration: none;
+  }
+  span {
+    font-size: 16px;
+    color: #FFFFFF;
+    padding: 14px 75px;
+  }
+}

--- a/src/components/PageSections/EventsHomePage/_EventsHomePage.scss
+++ b/src/components/PageSections/EventsHomePage/_EventsHomePage.scss
@@ -41,15 +41,14 @@
   font-size: 16px;
   color: #FFFFFF;
   padding-top: 14px;
-  padding-left: 102px;
   line-height: 20px;
   width: 314px;
   height: 48px;
   background-color: #0050D8;
   border-radius: 4px;
+  text-align: center;
   @include media($coa-medium-screen) {
     width: 260px;
     height: 48px;
-    padding-left: 75px;
   }
 }

--- a/src/components/PageSections/EventsHomePage/_EventsHomePage.scss
+++ b/src/components/PageSections/EventsHomePage/_EventsHomePage.scss
@@ -5,16 +5,33 @@
   margin-left: auto;
 }
 
+.coa-EventsHomePage__heading {
+  font-size: 40px;
+  color: #171717;
+  font-weight: 500;
+  margin-bottom: 40px;
+}
+
+.coa-EventsHomePage__events {
+  display: flex;
+  flex-direction: row;
+}
+
 .coa-EventsHomePage__allEventsButton {
-  height: 48px;
   width: 260px;
+  height: 48px;
+  text-decoration: none;
+  display: block;
+}
+
+.coa-EventsHomePage__allEventsButton--inner {
+  font-size: 16px;
+  color: #FFFFFF;
+  padding-top: 14px;
+  padding-left: 75px;
+  line-height: 20px;
+  width: 260px;
+  height: 48px;
   background-color: #0050D8;
-  a {
-    text-decoration: none;
-  }
-  span {
-    font-size: 16px;
-    color: #FFFFFF;
-    padding: 14px 75px;
-  }
+  border-radius: 4px;
 }

--- a/src/components/PageSections/EventsHomePage/_EventsHomePage.scss
+++ b/src/components/PageSections/EventsHomePage/_EventsHomePage.scss
@@ -3,6 +3,7 @@
   max-width: $coa-wrapper-maxwidth;
   margin-right: auto;
   margin-left: auto;
+  background-color: #ffffff;
 }
 
 .coa-EventsHomePage__heading {

--- a/src/components/PageSections/EventsHomePage/_EventsHomePage.scss
+++ b/src/components/PageSections/EventsHomePage/_EventsHomePage.scss
@@ -17,7 +17,7 @@
 }
 
 .coa-EventsHomePage__events {
-  @include media($coa-medium-screen) {
+  @include media($coa-large-screen) {
     display: flex;
     flex-direction: row;
   }
@@ -30,6 +30,7 @@
   display: block;
   margin: auto;
   margin-top: 10px;
+  padding-top: 10px;
   @include media($coa-medium-screen) {
     width: 260px;
     height: 48px;

--- a/src/components/PageSections/EventsHomePage/_EventsHomePage.scss
+++ b/src/components/PageSections/EventsHomePage/_EventsHomePage.scss
@@ -13,25 +13,39 @@
 }
 
 .coa-EventsHomePage__events {
-  display: flex;
-  flex-direction: row;
+  @include media($coa-medium-screen) {
+    display: flex;
+    flex-direction: row;
+  }
 }
 
 .coa-EventsHomePage__allEventsButton {
-  width: 260px;
+  width: 314px;
   height: 48px;
   text-decoration: none;
   display: block;
+  margin: auto;
+  margin-top: 10px;
+  @include media($coa-medium-screen) {
+    width: 260px;
+    height: 48px;
+    margin: unset;
+  }
 }
 
 .coa-EventsHomePage__allEventsButton--inner {
   font-size: 16px;
   color: #FFFFFF;
   padding-top: 14px;
-  padding-left: 75px;
+  padding-left: 102px;
   line-height: 20px;
-  width: 260px;
+  width: 314px;
   height: 48px;
   background-color: #0050D8;
   border-radius: 4px;
+  @include media($coa-medium-screen) {
+    width: 260px;
+    height: 48px;
+    padding-left: 75px;
+  }
 }

--- a/src/components/PageSections/EventsHomePage/_EventsHomePage.scss
+++ b/src/components/PageSections/EventsHomePage/_EventsHomePage.scss
@@ -6,10 +6,14 @@
 }
 
 .coa-EventsHomePage__heading {
-  font-size: 40px;
+  font-size: 32px;
   color: #171717;
   font-weight: 500;
-  margin-bottom: 40px;
+  margin-bottom: 30px;
+  @include media($coa-medium-screen) {
+    font-size: 40px;
+    margin-bottom: 40px;
+  }
 }
 
 .coa-EventsHomePage__events {

--- a/src/components/PageSections/EventsHomePage/index.js
+++ b/src/components/PageSections/EventsHomePage/index.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useIntl } from 'react-intl';
+import { Link } from 'react-router-dom';
+
+const EventsHomePage = () => {
+  const intl = useIntl();
+
+  return (
+    <div className="coa-EventsHomePage__container">
+      <Link
+        to={`/${intl.locale}/events`}
+        className="coa-EventsHomePage__allEventsButton"
+      >
+        <span>View all events</span>
+      </Link>
+    </div>
+  )
+}
+
+export default EventsHomePage;

--- a/src/components/PageSections/EventsHomePage/index.js
+++ b/src/components/PageSections/EventsHomePage/index.js
@@ -16,7 +16,6 @@ const filterEvents = (events) => {
 const EventsHomePage = ({events}) => {
   const intl = useIntl();
   const threeEvents = filterEvents(events);
-  console.log(threeEvents);
 
   return (
     (threeEvents && !!threeEvents.length) &&

--- a/src/components/PageSections/EventsHomePage/index.js
+++ b/src/components/PageSections/EventsHomePage/index.js
@@ -19,7 +19,7 @@ const EventsHomePage = ({events}) => {
   console.log(threeEvents);
 
   return (
-    threeEvents && threeEvents.length &&
+    (threeEvents && !!threeEvents.length) &&
     <div className="coa-EventsHomePage__container">
       <div className="coa-EventsHomePage__heading">
         {intl.formatMessage(i18n.upcoming)}

--- a/src/components/PageSections/EventsHomePage/index.js
+++ b/src/components/PageSections/EventsHomePage/index.js
@@ -7,14 +7,17 @@ import EventListEntry from 'components/Pages/EventList/EventListEntry';
 import { events as i18n } from 'js/i18n/definitions';
 
 const filterEvents = (events) => {
-  const dateNow = moment().format('YYYY-MM-DD')
-  return events.filter((e) => moment(e.date).isSameOrAfter(dateNow)).slice(0,3);
+  const dateNow = moment().tz('America/Chicago').format('YYYY-MM-DD')
+  let currentEvents = events.filter((e) => moment(e.date).isSameOrAfter(dateNow));
+
+  return currentEvents.filter((e) => !e.canceled).slice(0,3);
 }
 
 
 const EventsHomePage = ({events}) => {
   const intl = useIntl();
   const threeEvents = filterEvents(events);
+  console.log(threeEvents);
 
   return (
     threeEvents && threeEvents.length &&

--- a/src/components/PageSections/EventsHomePage/index.js
+++ b/src/components/PageSections/EventsHomePage/index.js
@@ -8,9 +8,8 @@ import { events as i18n } from 'js/i18n/definitions';
 
 const filterEvents = (events) => {
   const dateNow = moment().tz('America/Chicago').format('YYYY-MM-DD')
-  let currentEvents = events.filter((e) => moment(e.date).isSameOrAfter(dateNow));
 
-  return currentEvents.filter((e) => !e.canceled).slice(0,3);
+  return events.filter((e) => moment(e.date).isSameOrAfter(dateNow)).slice(0,3);
 }
 
 

--- a/src/components/PageSections/EventsHomePage/index.js
+++ b/src/components/PageSections/EventsHomePage/index.js
@@ -1,18 +1,42 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
+import moment from 'moment-timezone';
 
-const EventsHomePage = () => {
+import EventListEntry from 'components/Pages/EventList/EventListEntry';
+
+const filterEvents = (events) => {
+  const dateNow = moment().format('YYYY-MM-DD')
+  return events.filter((e) => moment(e.date).isSameOrAfter(dateNow)).slice(0,3);
+}
+
+
+const EventsHomePage = ({events}) => {
   const intl = useIntl();
+  const threeEvents = filterEvents(events);
 
   return (
+    threeEvents && threeEvents.length &&
     <div className="coa-EventsHomePage__container">
+      <div className="coa-EventsHomePage__heading">
+        Upcoming events
+      </div>
+
+      <div className="coa-EventsHomePage__events">
+        {threeEvents.map(e => (
+          <EventListEntry event={e} homepage={true} />
+        ))}
+      </div>
+
       <Link
         to={`/${intl.locale}/events`}
         className="coa-EventsHomePage__allEventsButton"
       >
-        <span>View all events</span>
+        <div className="coa-EventsHomePage__allEventsButton--inner">
+          View all events 
+        </div>
       </Link>
+
     </div>
   )
 }

--- a/src/components/PageSections/EventsHomePage/index.js
+++ b/src/components/PageSections/EventsHomePage/index.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import moment from 'moment-timezone';
 
 import EventListEntry from 'components/Pages/EventList/EventListEntry';
+import { events as i18n } from 'js/i18n/definitions';
 
 const filterEvents = (events) => {
   const dateNow = moment().format('YYYY-MM-DD')
@@ -19,7 +20,7 @@ const EventsHomePage = ({events}) => {
     threeEvents && threeEvents.length &&
     <div className="coa-EventsHomePage__container">
       <div className="coa-EventsHomePage__heading">
-        Upcoming events
+        {intl.formatMessage(i18n.upcoming)}
       </div>
 
       <div className="coa-EventsHomePage__events">
@@ -33,7 +34,7 @@ const EventsHomePage = ({events}) => {
         className="coa-EventsHomePage__allEventsButton"
       >
         <div className="coa-EventsHomePage__allEventsButton--inner">
-          View all events 
+          {intl.formatMessage(i18n.viewAll)}
         </div>
       </Link>
 

--- a/src/components/Pages/EventList/EventListEntry.js
+++ b/src/components/Pages/EventList/EventListEntry.js
@@ -37,7 +37,7 @@ const EventDateCalendar = ({date}) => {
 }
 
 
-const EventDateListDetails = ({ event }) => {
+const EventDateListDetails = ({ event, homepage }) => {
   const intl = useIntl();
   const isMobile = useMobileQuery()
   let dayType = isMobile ? 'ddd' : 'dddd';
@@ -75,7 +75,9 @@ const EventDateListDetails = ({ event }) => {
   }
 
   return (
-    <div className="coa-EventListPage__EntryDetails"> 
+    <div
+      className={classNames('coa-EventListPage__EntryDetails', 
+          {'coa-EventListPage__EntryDetails--homepage': homepage} )}> 
       { 
         canceled 
         && <div className="coa-EventListPage__Canceled">
@@ -97,7 +99,7 @@ const EventListEntry = ({ event, homepage }) => {
       className={classNames('coa-EventListPage__Entry', {'coa-EventListPage__Entry--homepage': homepage})}
     >
       <EventDateCalendar date={event.date} />
-      <EventDateListDetails event={event}/>
+      <EventDateListDetails event={event} homepage={homepage}/>
     </Link>
   )
 }

--- a/src/components/Pages/EventList/EventListEntry.js
+++ b/src/components/Pages/EventList/EventListEntry.js
@@ -2,6 +2,7 @@ import React from 'react';
 import moment from 'moment-timezone';
 import { useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
+import classNames from 'classnames';
 
 import { useMobileQuery } from 'js/helpers/reactMediaQueries.js';
 import { formatTime, formatHours } from 'js/helpers/cleanData';
@@ -90,9 +91,12 @@ const EventDateListDetails = ({ event }) => {
   )
 }
 
-const EventListEntry = ({event}) => {
+const EventListEntry = ({ event, homepage }) => {
   return (
-    <Link to={event.eventUrl} className="coa-EventListPage__Entry">
+    <Link
+      to={event.eventUrl}
+      className={classNames('coa-EventListPage__Entry', {'coa-EventListPage__Entry--homepage': homepage})}
+    >
       <EventDateCalendar date={event.date} />
       <EventDateListDetails event={event}/>
     </Link>

--- a/src/components/Pages/Home.js
+++ b/src/components/Pages/Home.js
@@ -15,7 +15,7 @@ import UserFeedback from 'components/UserFeedback';
 import TileGroup from 'components/Tiles/TileGroup';
 
 const Home = ({ intl }) => {
-  const { topServices, image } = useRouteData();
+  const { topServices, image, events } = useRouteData();
 
   return (
     <div className="coa-HeroHome__container">
@@ -34,7 +34,9 @@ const Home = ({ intl }) => {
         tiles={topServices}
       />
 
-      <EventsHomePage />
+      <EventsHomePage
+        events={events}
+      />
 
       {/* We are leaving it here because we might need it again.*/}
       {/*<PageNotificationBanner>*/}

--- a/src/components/Pages/Home.js
+++ b/src/components/Pages/Home.js
@@ -9,6 +9,7 @@ import PageNotificationBanner from 'components/PageNotificationBanner';
 import HeroHome from 'components/HeroHome';
 import ExternalLink from 'components/ExternalLink';
 import SectionHeader from 'components/SectionHeader';
+import EventsHomePage from 'components/PageSections/EventsHomePage';
 import UserFeedback from 'components/UserFeedback';
 
 import TileGroup from 'components/Tiles/TileGroup';
@@ -33,6 +34,7 @@ const Home = ({ intl }) => {
         tiles={topServices}
       />
 
+      <EventsHomePage />
 
       {/* We are leaving it here because we might need it again.*/}
       {/*<PageNotificationBanner>*/}

--- a/src/components/Pages/_EventList.scss
+++ b/src/components/Pages/_EventList.scss
@@ -15,9 +15,10 @@
 }
 
 .coa-EventListPage__Entry--homepage {
-  width: 364px;
-  @include media($coa-medium-screen) {
+  max-width: 760px;
+  @include media($coa-large-screen) {
     border-bottom: 0;
+    width: 356px;
   }
 }
 
@@ -87,14 +88,14 @@
 
 .coa-EventListPage__EntryDetails {
   margin-left: 24px;
-  width: 233px;
+  min-width: 189px;
   @include media($coa-medium-screen){
     width: 637px;
   }
 }
 
 .coa-EventListPage__EntryDetails--homepage {
-  @include media($coa-medium-screen){
+  @include media($coa-large-screen){
     max-width: 250px;
   }
 }

--- a/src/components/Pages/_EventList.scss
+++ b/src/components/Pages/_EventList.scss
@@ -14,6 +14,11 @@
   }
 }
 
+.coa-EventListPage__Entry--homepage {
+  border-bottom: 0;
+  width: 364px;
+}
+
 .coa-EventListPage__DateCal {
   width: 71px;
   height: 80px;

--- a/src/components/Pages/_EventList.scss
+++ b/src/components/Pages/_EventList.scss
@@ -15,8 +15,10 @@
 }
 
 .coa-EventListPage__Entry--homepage {
-  border-bottom: 0;
   width: 364px;
+  @include media($coa-medium-screen) {
+    border-bottom: 0;
+  }
 }
 
 .coa-EventListPage__DateCal {
@@ -28,6 +30,17 @@
     width: 88px;
   }
 }
+
+.coa-EventListPage__DateCal--homepage {
+  width: 71px;
+  height: 80px;
+  background-color: #F7F9FA;
+  @include media($coa-medium-screen) {
+    height: 112px;
+    width: 88px;
+  }
+}
+
 
 .coa-EventListPage__DateCal-month {
   background-color: #F1F3F6;
@@ -71,11 +84,18 @@
     font-size: 10px;
   }
 }
+
 .coa-EventListPage__EntryDetails {
   margin-left: 24px;
   width: 233px;
   @include media($coa-medium-screen){
     width: 637px;
+  }
+}
+
+.coa-EventListPage__EntryDetails--homepage {
+  @include media($coa-medium-screen){
+    max-width: 250px;
   }
 }
 

--- a/src/components/Pages/_EventList.scss
+++ b/src/components/Pages/_EventList.scss
@@ -66,6 +66,9 @@
   color: #171717;
   @include media($coa-medium-screen) {
     line-height: 78px;
+    font-size: 32px;
+  }
+  @include media($coa-large-screen) {
     font-size: 40px;
   }
 }

--- a/src/css/coa.scss
+++ b/src/css/coa.scss
@@ -71,4 +71,5 @@
 @import 'components/PageSections/PendingTranslation/PendingTranslation';
 @import 'components/Pages/Location/Location';
 @import 'components/Pages/Event';
-@import 'components/Pages/EventList'
+@import 'components/Pages/EventList';
+@import 'components/PageSections/EventsHomePage/EventsHomePage';

--- a/src/js/i18n/definitions.js
+++ b/src/js/i18n/definitions.js
@@ -527,4 +527,6 @@ export const events = defineMessages({
   events: 'Events',
   registrationReq: 'Registration required',
   noon: 'Noon',
+  upcoming: "Upcoming events",
+  viewAll: "View all events"
 });

--- a/src/js/i18n/locales/es.json
+++ b/src/js/i18n/locales/es.json
@@ -135,5 +135,7 @@
   "events.getDirections": "Obtener direcciones",
   "events.events": "Eventos",
   "events.registrationReq": "Registración requerido",
-  "events.noon": "Mediodía"
+  "events.noon": "Mediodía",
+  "events.upcoming": "Próximos eventos",
+  "events.viewAll": "Ver todos los eventos"
 }

--- a/src/js/queries/getEventPageQuery.js
+++ b/src/js/queries/getEventPageQuery.js
@@ -1,8 +1,8 @@
 import eventPageFragment from './eventPageFragment';
 
 const getEventPageQuery = `
-  query getEventPage($id: ID, $date_Lte: Date, $date_Gte: Date) {
-    allEventPages(orderBy:"date", id:$id, date_Lte:$date_Lte, date_Gte:$date_Gte) {
+  query getEventPage($id: ID, $date_Lte: Date, $date_Gte: Date, $canceled: Boolean) {
+    allEventPages(orderBy:"date", id:$id, date_Lte:$date_Lte, date_Gte:$date_Gte, canceled: $canceled) {
       edges {
         node {
           ...eventPageInfo

--- a/src/js/queries/getEventPageQuery.js
+++ b/src/js/queries/getEventPageQuery.js
@@ -2,7 +2,7 @@ import eventPageFragment from './eventPageFragment';
 
 const getEventPageQuery = `
   query getEventPage($id: ID, $date_Lte: Date, $date_Gte: Date, $canceled: Boolean) {
-    allEventPages(orderBy:"date", id:$id, date_Lte:$date_Lte, date_Gte:$date_Gte, canceled: $canceled) {
+    allEventPages(orderBy:"date", id:$id, date_Lte:$date_Lte, date_Gte:$date_Gte, canceled: $canceled, live:true) {
       edges {
         node {
           ...eventPageInfo

--- a/static.config.js
+++ b/static.config.js
@@ -904,7 +904,6 @@ const makeAllPages = async (langCode, incrementalPageId) => {
           index === services.findIndex(s => s.id === service.id),
       );
 
-      // bookmark
       const topServices = services.map(s => ({
         type: !!langCode ? langCode : 'en',
         url: s.url,

--- a/static.config.js
+++ b/static.config.js
@@ -573,7 +573,6 @@ const getEventPageData = async (id, client) => {
 };
 
 const getAllEvents = async client => {
-  // Is this how we want to handle it? 
   const date_now = moment().format('YYYY-MM-DD')
   const { allEventPages } = await client.request(getEventPageQuery, {
     date_Gte: date_now,
@@ -873,11 +872,14 @@ const makeAllPages = async (langCode, incrementalPageId) => {
           index === services.findIndex(s => s.id === service.id),
       );
 
+      // bookmark
       const topServices = services.map(s => ({
         type: !!langCode ? langCode : 'en',
         url: s.url,
         title: s.title,
       }));
+
+      const allEvents = await getAllEvents(client);
 
       return {
         topServices,
@@ -885,6 +887,7 @@ const makeAllPages = async (langCode, incrementalPageId) => {
           file: 'tomek-baginski-593896-unsplash',
           title: 'Lady Bird Lake',
         },
+        events: allEvents.events,
       };
     },
   };

--- a/static.config.js
+++ b/static.config.js
@@ -749,13 +749,8 @@ const buildPageAtUrl = async (pageAtUrlInfo, client, pagesOfGuides) => {
     return {
       path: url,
       template: 'src/components/Pages/EventList',
-<<<<<<< HEAD
       getData: () => getAllEvents(client, false)
     }
-=======
-      getData: () => getAllEvents(client),
-    };
->>>>>>> master
   }
 };
 

--- a/static.config.js
+++ b/static.config.js
@@ -574,9 +574,8 @@ const getEventPageData = async (id, client) => {
 
 const getAllEvents = async (client, hideCanceled) => {
   const date_now = moment().tz('America/Chicago').format('YYYY-MM-DD')
-  const {allEventPages} = await client.request(getEventPageQuery, {
-    date_Gte: date_now, canceled: !hideCanceled,
-  })
+  const gqlVariables = hideCanceled ? { date_Gte: date_now, canceled: false } : { date_Gte: date_now };
+  const {allEventPages} = await client.request(getEventPageQuery, gqlVariables)
 
   const events = allEventPages.edges.map(edge => ({
     title: edge.node.title,

--- a/static.config.js
+++ b/static.config.js
@@ -572,11 +572,11 @@ const getEventPageData = async (id, client) => {
   return { eventPage: eventPage };
 };
 
-const getAllEvents = async client => {
+const getAllEvents = async (client, hideCanceled) => {
   const date_now = moment().tz('America/Chicago').format('YYYY-MM-DD')
-  const { allEventPages } = await client.request(getEventPageQuery, {
-    date_Gte: date_now,
-  });
+  const {allEventPages} = await client.request(getEventPageQuery, {
+    date_Gte: date_now, canceled: !hideCanceled,
+  })
 
   const events = allEventPages.edges.map(edge => ({
     title: edge.node.title,
@@ -750,7 +750,7 @@ const buildPageAtUrl = async (pageAtUrlInfo, client, pagesOfGuides) => {
     return {
       path: url,
       template: 'src/components/Pages/EventList',
-      getData: () => getAllEvents(client)
+      getData: () => getAllEvents(client, false)
     }
   }
 };
@@ -879,7 +879,7 @@ const makeAllPages = async (langCode, incrementalPageId) => {
         title: s.title,
       }));
 
-      const allEvents = await getAllEvents(client);
+      const allActiveEvents = await getAllEvents(client, true);
 
       return {
         topServices,
@@ -887,7 +887,7 @@ const makeAllPages = async (langCode, incrementalPageId) => {
           file: 'tomek-baginski-593896-unsplash',
           title: 'Lady Bird Lake',
         },
-        events: allEvents.events,
+        events: allActiveEvents.events,
       };
     },
   };


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

This branch adds the home page events view. 

I added components on the homepage and also had to change the query up a bit since we aren't showing canceled events on the homepage. 


<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
   <!--- Netlify Example: `https://janis-<PR>.netlify.com/` --->  
https://janis-3818-event-home.netlify.com/


# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
