### PR TITLE
3921 - clickable rich text buttons

### DIFF
--- a/src/components/HtmlFromRichText/index.js
+++ b/src/components/HtmlFromRichText/index.js
@@ -48,22 +48,24 @@ const HtmlFromRichText = ({ content }) => {
           domNode.attribs.style = '';
         }
 
-        // Turn links into buttons
-        // waiting on
-        // if (
-        //   domNode.attribs.hasOwnProperty('href') &&
-        //   domNode.parent.name !== 'li'
-        // ) {
-        //   // replace the node with a button
-        //   return (
-        //     <a class="usa-button-primary" href={domNode.attribs.href}>
-        //       {/* this is kinda goofy, but the 'data' is the text of the link
-        //                and html-parser reads that as a child of 'a' */}
+        // If we're getting the button div from drafttail, we need to turn it into
+        // an 'a' tag to make the whole thing a link
+        if (
+          domNode.attribs.class &&
+          domNode.attribs.class.includes('rich-text-button-link')
+        ) {
+          const child = domNode.children && domNode.children[0];
+          if (child && child.name === 'a') {
+            // make it a link not a div
+            domNode.name = 'a';
 
-        //       {domNode.children[0].data}
-        //     </a>
-        //   );
-        // }
+            // get the href from the wrapped link
+            domNode.attribs.href = child.attribs.href;
+
+            // get child text element from the wrapped link
+            domNode.children = child.children;
+          }
+        }
       }
     },
   });


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description
Instead of having linked text in a div let's just make the whole button a link. This is just doing it in HtmlFromRichText instead of messing with drafttail

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->
https://github.com/cityofaustin/techstack/issues/3921

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
   <!--- Netlify Example: `https://janis-<PR>.netlify.com/` --->  
1. Go here: https://janis-3921-clickable-buttons.netlify.com//en/government-business/business-resources-3/workforce-development-and-hiring/hire-a-day-laborer/
2. Expand "online" option in step 3
3. Notice entire "start" button is an 'a' element

# Checklist:
- [x] Request reviewers
- [x] Slack-out message for review
- [x] Link this PR in the issue
- [x] Moved card to *review* in zenhub
