### PR TITLE
3690 incremental

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,17 @@ jobs:
       - run:
           name: "Triggering netlify build"
           command: node ./.circleci/scripts/buildNetlifySite.js
+  deploy-publisher-v2:
+    docker:
+      - image: cityofaustin/janis-ci-deploy:d456c15
+    steps:
+      - checkout
+      - run:
+          name: "Print App Environment Variables"
+          command: bash ./.circleci/scripts/print_vars.sh
+      - run:
+          name: "Triggering netlify build"
+          command: node ./.circleci/scripts/buildNetlifySite.js
 
 workflows:
   version: 2.1
@@ -23,3 +34,4 @@ workflows:
               ignore:
                 - master
                 - production
+      - deploy-publisher-v2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: "Print App Environment Variables"
           command: bash ./.circleci/scripts/print_vars.sh
       - run:
-          name: "Triggering netlify build"
+          name: "Triggering publisher v2 build"
           command: node ./.circleci/scripts/buildPublisherV2.js
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,3 +35,8 @@ workflows:
                 - master
                 - production
       - deploy-publisher-v2
+          filters:
+            branches:
+              ignore:
+                - master
+                - production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           command: bash ./.circleci/scripts/print_vars.sh
       - run:
           name: "Triggering netlify build"
-          command: node ./.circleci/scripts/buildNetlifySite.js
+          command: node ./.circleci/scripts/buildPublisherV2.js
 
 workflows:
   version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ workflows:
               ignore:
                 - master
                 - production
-      - deploy-publisher-v2
+      - deploy-publisher-v2:
           filters:
             branches:
               ignore:

--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -21,6 +21,7 @@ const defaultValues = {
   CMS_API: 'https://joplin-staging.herokuapp.com/api/graphql',
   CMS_MEDIA: 'https://joplin-austin-gov-static.s3.amazonaws.com/staging/media',
   CMS_DOCS: 'multiple',
+  REACT_STATIC_PREFETCH_RATE: 0, // Don't do prefetching by default
 };
 
 // Add branch-specifc values here
@@ -38,7 +39,8 @@ const branchOverrides = {
     CMS_API: 'https://joplin-pr-3244-guide-icon-tile.herokuapp.com/api/graphql'
   },
   '3690-incremental': {
-    CMS_API: 'https://joplin-pr-3690-incremental.herokuapp.com/api/graphql'
+    CMS_API: 'https://joplin-pr-3690-incremental.herokuapp.com/api/graphql',
+    REACT_STATIC_PREFETCH_RATE: 10,
   }
 };
 

--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -21,7 +21,7 @@ const defaultValues = {
   CMS_API: 'https://joplin-staging.herokuapp.com/api/graphql',
   CMS_MEDIA: 'https://joplin-austin-gov-static.s3.amazonaws.com/staging/media',
   CMS_DOCS: 'multiple',
-  REACT_STATIC_PREFETCH_RATE: 0, // Don't do prefetching by default
+  REACT_STATIC_PREFETCH_RATE: '0', // Don't do prefetching by default
 };
 
 // Add branch-specifc values here
@@ -40,7 +40,7 @@ const branchOverrides = {
   },
   '3690-incremental': {
     CMS_API: 'https://joplin-pr-3690-incremental.herokuapp.com/api/graphql',
-    REACT_STATIC_PREFETCH_RATE: 10,
+    REACT_STATIC_PREFETCH_RATE: '10',
   }
 };
 

--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -37,6 +37,9 @@ const branchOverrides = {
   '3244-guide-icon-tiles': {
     CMS_API: 'https://joplin-pr-3244-guide-icon-tile.herokuapp.com/api/graphql'
   },
+  '3690-incremental': {
+    CMS_API: 'https://joplin-pr-3690-incremental.herokuapp.com/api/graphql'
+  }
 };
 
 module.exports = {

--- a/.circleci/scripts/buildPublisherV2.js
+++ b/.circleci/scripts/buildPublisherV2.js
@@ -1,0 +1,53 @@
+const axios = require('axios');
+
+const { defaultValues, branchOverrides } = require("./branchConfig.js")
+const branch = process.env.CIRCLE_BRANCH;
+
+const env_vars = Object.assign(
+  defaultValues,
+  branchOverrides[branch]
+);
+
+// In Publisher v2, the joplin_appname is passed separately from the rest of the env_vars
+const CMS_API = env_vars.CMS_API;
+delete env_vars.CMS_API;
+const joplin_appname = CMS_API.match(new RegExp('(?:https://)(.*)(?:.herokuapp.com/api/graphql)'))[1]
+
+const payload = {
+  "janis_branch": branch,
+  "env_vars": env_vars,
+  "joplin_appname": joplin_appname,
+  "build_type": "rebuild",
+};
+
+let apiKey, publisherUrl;
+switch(branch):
+  case "master":
+    apiKey = process.env.COA_PUBLISHER_V2_API_KEY_STAGING
+    publisherUrl = process.env.CI_COA_PUBLISHER_V2_URL_STAGING
+    break;
+  case "production":
+    apiKey = process.env.COA_PUBLISHER_V2_API_KEY_PROD
+    publisherUrl = process.env.CI_COA_PUBLISHER_V2_URL_PROD
+    break;
+  default:
+    apiKey = process.env.COA_PUBLISHER_V2_API_KEY_PR
+    publisherUrl = process.env.CI_COA_PUBLISHER_V2_URL_PR
+
+const headers = {
+  'Content-Type': 'application/json',
+  "x-api-key": apiKey,
+}
+
+return axios.post(publisherUrl, payload, {"headers": headers})
+.then((res) => {
+  console.log("Success")
+  console.log("New build instructions sent to coa-publisher v2")
+  console.log(res)
+  process.exit(0)
+})
+.catch((error) => {
+  console.log("Failure")
+  console.error(error)
+  process.exit(1)
+})

--- a/.circleci/scripts/buildPublisherV2.js
+++ b/.circleci/scripts/buildPublisherV2.js
@@ -44,7 +44,7 @@ return axios.post(publisherUrl, payload, {"headers": headers})
 .then((res) => {
   console.log("Success")
   console.log("New build instructions sent to coa-publisher v2")
-  console.log(res)
+  console.log(res.data)
   process.exit(0)
 })
 .catch((error) => {

--- a/.circleci/scripts/buildPublisherV2.js
+++ b/.circleci/scripts/buildPublisherV2.js
@@ -21,7 +21,7 @@ const payload = {
 };
 
 let apiKey, publisherUrl;
-switch(branch):
+switch(branch) {
   case "master":
     apiKey = process.env.COA_PUBLISHER_V2_API_KEY_STAGING
     publisherUrl = process.env.CI_COA_PUBLISHER_V2_URL_STAGING
@@ -33,6 +33,7 @@ switch(branch):
   default:
     apiKey = process.env.COA_PUBLISHER_V2_API_KEY_PR
     publisherUrl = process.env.CI_COA_PUBLISHER_V2_URL_PR
+}
 
 const headers = {
   'Content-Type': 'application/json',

--- a/static.config.js
+++ b/static.config.js
@@ -1007,5 +1007,5 @@ export default {
     return config;
   },
   plugins: ['react-static-plugin-react-router'],
-  prefetchRate: 4,
+  prefetchRate: Number(process.env.REACT_STATIC_PREFETCH_RATE) || 0,
 };

--- a/static.config.js
+++ b/static.config.js
@@ -1007,4 +1007,5 @@ export default {
     return config;
   },
   plugins: ['react-static-plugin-react-router'],
+  prefetchRate: 4,
 };


### PR DESCRIPTION
Issue: cityofaustin/techstack#3690

Cool. This is adding the stuff for Janis's CircleCI process to talk to the publisher.
- CircleCI runs 2 deployment processes - one for the mvp publisher, one for the new publisher. Just for the sake of transition/testing temporarily.
- We now set REACT_STATIC_PREFETCH_RATE add an env variable.

How to test:
- When you branch off this code, your new branch will deploy with the new publisher to "janis-v3-[branch-name]" on netlify.