### PR TITLE
change relatedDepartments to departments

### DIFF
--- a/scripts/build-full.sh
+++ b/scripts/build-full.sh
@@ -12,7 +12,7 @@
 
 export NODE_PATH='./src'
 
-export CMS_API='https://joplin.herokuapp.com/api/graphql'
+export CMS_API='https://joplin-staging.herokuapp.com/api/graphql'
 export CMS_MEDIA='https://joplin-austin-gov-static.s3.amazonaws.com/staging/media'
 
 yarn npm-run-all build-css build-js

--- a/scripts/build-full.sh
+++ b/scripts/build-full.sh
@@ -12,7 +12,7 @@
 
 export NODE_PATH='./src'
 
-export CMS_API='https://joplin-staging.herokuapp.com/api/graphql'
+export CMS_API='https://joplin.herokuapp.com/api/graphql'
 export CMS_MEDIA='https://joplin-austin-gov-static.s3.amazonaws.com/staging/media'
 
 yarn npm-run-all build-css build-js

--- a/src/js/queries/guidePageFragment.js
+++ b/src/js/queries/guidePageFragment.js
@@ -109,16 +109,10 @@ const guidePageFragment = `
               }
             }
           }
-          relatedDepartments {
-            edges {
-              node {
-                relatedDepartment {
-                  id
-                  title
-                  slug
-                }
-              }
-            }
+          departments {
+            id
+            title
+            slug
           }
         }
         informationPage {
@@ -150,17 +144,6 @@ const guidePageFragment = `
                       }
                     }
                   }
-                }
-              }
-            }
-          }
-          relatedDepartments {
-            edges {
-              node {
-                relatedDepartment {
-                  id
-                  title
-                  slug
                 }
               }
             }

--- a/src/stories/pages/GuidePage/GuidePage.data.js
+++ b/src/stories/pages/GuidePage/GuidePage.data.js
@@ -79,7 +79,7 @@ export const basicData = () => ({
     "filename": "austincoverphoto.jpg",
     "title": "Aerial photo of the Austin skyline looking over from Town Lake"
   },
-  "relatedDepartments": {
+  "departments": {
     "edges": [
       {
         "node": {


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description
Guide pages preview was broken, due to the query not being correct. 

There are _other_ places where it looks like the old variable still persisted, but I left them alone to be conservative. 

But they should be fixed, yah? Just search the code for 'relatedDepartments' and you'll find them. 

The preview also has another bug in the contextual nav where it's resolving to ```enfood-business-permits```. This PR does not address that. 
<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
   <!--- Netlify Example: `https://janis-<PR>.netlify.com/` --->  

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
