### PR TITLE
4053 scroll to top

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
-import React, { Component, Fragment, Suspense } from 'react';
-import { Root, Routes, useSiteData } from 'react-static';
+import React, { Component, Fragment, Suspense, useEffect } from 'react';
+import { Root, useSiteData } from 'react-static';
 import { Route, Switch } from 'react-router';
+import { useLocation } from "react-router-dom";
 import { useIntl } from 'react-intl';
 import { LANG_URL_REGEX } from 'js/i18n/constants';
 import CMSPreview from 'components/_Controllers/CMSPreview';
@@ -12,6 +13,17 @@ import Footer from 'components/PageSections/Footer';
 
 import 'css/coa.css';
 
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}
+
 const AppView = ({path}) => {
   const intl = useIntl();
   const { navigation } = useSiteData();
@@ -21,6 +33,7 @@ const AppView = ({path}) => {
       <SkipToMain />
       <Header navigation={navigation[intl.locale]} path={path} />
       <main role="main" id="main">
+        <ScrollToTop />
         <Switch>
           <Route
             path={`${LANG_URL_REGEX}preview/:page_type/:revision_id`}


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Scroll position is being maintained even when navigating to a different page. Here's the fix:
https://reacttraining.com/react-router/web/guides/scroll-restoration/scroll-to-top

I remember there may be some weirdness with using `window` when we use it in prod. Will this work? 


<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->
https://janis-4053-scroll-position.netlify.com/

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
   <!--- Netlify Example: `https://janis-<PR>.netlify.com/` --->  

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
