### PR TITLE
4059 - addresses include a link to open map

### DIFF
--- a/src/components/Contact/Address.js
+++ b/src/components/Contact/Address.js
@@ -20,12 +20,12 @@ const Address = ({ location }) => {
         {location.city}, {location.state} {location.zip}
       </span>
       <a
-          href={`//www.google.com/maps/search/?api=1&query=${encodedLocation}`}
-          className="coa-EventDetailItem__location-directions-link"
-          target="_blank"
-        >
-          {intl.formatMessage(i18n.getDirections)}
-        </a>
+        href={`//www.google.com/maps/search/?api=1&query=${encodedLocation}`}
+        className="coa-EventDetailItem__location-directions-link"
+        target="_blank"
+      >
+        {intl.formatMessage(i18n.getDirections)}
+      </a>
     </div>
   </div>
 )};

--- a/src/components/Contact/Address.js
+++ b/src/components/Contact/Address.js
@@ -1,9 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useIntl } from 'react-intl';
+import { getEncodedLocation } from 'js/helpers/location';
+import { events as i18n } from 'js/i18n/definitions';
 
 import { addressPropTypes } from './proptypes';
 
-const Address = ({ location }) => (
+const Address = ({ location }) => {
+  const intl = useIntl();
+  const encodedLocation = getEncodedLocation(location);
+
+  return (
   <div className="coa-ContactItem coa-ContactAddress">
     <i className="material-icons">place</i>
     <div>
@@ -12,9 +19,16 @@ const Address = ({ location }) => (
       <span>
         {location.city}, {location.state} {location.zip}
       </span>
+      <a
+          href={`//www.google.com/maps/search/?api=1&query=${encodedLocation}`}
+          className="coa-EventDetailItem__location-directions-link"
+          target="_blank"
+        >
+          {intl.formatMessage(i18n.getDirections)}
+        </a>
     </div>
   </div>
-);
+)};
 
 Address.propTypes = {
   location: addressPropTypes,

--- a/src/components/Contact/Address.js
+++ b/src/components/Contact/Address.js
@@ -11,23 +11,24 @@ const Address = ({ location }) => {
   const encodedLocation = getEncodedLocation(location);
 
   return (
-  <div className="coa-ContactItem coa-ContactAddress">
-    <i className="material-icons">place</i>
-    <div>
-      <span className="coa-ContactAddressTitle">{location.title}</span>
-      <span>{location.street}</span>
-      <span>
-        {location.city}, {location.state} {location.zip}
-      </span>
-      <a
-        href={`//www.google.com/maps/search/?api=1&query=${encodedLocation}`}
-        target="_blank"
-      >
-        {intl.formatMessage(i18n.getDirections)}
-      </a>
+    <div className="coa-ContactItem coa-ContactAddress">
+      <i className="material-icons">place</i>
+      <div>
+        <span className="coa-ContactAddressTitle">{location.title}</span>
+        <span>{location.street}</span>
+        <span>
+          {location.city}, {location.state} {location.zip}
+        </span>
+        <a
+          href={`//www.google.com/maps/search/?api=1&query=${encodedLocation}`}
+          target="_blank"
+        >
+          {intl.formatMessage(i18n.getDirections)}
+        </a>
+      </div>
     </div>
-  </div>
-)};
+  )
+};
 
 Address.propTypes = {
   location: addressPropTypes,

--- a/src/components/Contact/Address.js
+++ b/src/components/Contact/Address.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { getEncodedLocation } from 'js/helpers/location';
-import { events as i18n } from 'js/i18n/definitions';
+import { misc as i18n } from 'js/i18n/definitions';
 
 import { addressPropTypes } from './proptypes';
 
@@ -21,7 +21,6 @@ const Address = ({ location }) => {
       </span>
       <a
         href={`//www.google.com/maps/search/?api=1&query=${encodedLocation}`}
-        className="coa-EventDetailItem__location-directions-link"
         target="_blank"
       >
         {intl.formatMessage(i18n.getDirections)}

--- a/src/components/Pages/Department.js
+++ b/src/components/Pages/Department.js
@@ -17,7 +17,6 @@ import WorkInProgress from 'components/WorkInProgress';
 
 import TileGroup from 'components/Tiles/TileGroup';
 
-//rmv
 import { misc as i18n2, services as i18n3 } from 'js/i18n/definitions';
 
 const Department = ({ department, intl }) => {

--- a/src/components/Pages/Event/EventDetailCard/EventLocationDetail.js
+++ b/src/components/Pages/Event/EventDetailCard/EventLocationDetail.js
@@ -18,7 +18,8 @@ const EventLocationDetail = ({
   // From conversation with desi:
   /*
         Brian Smith  12:30 PM
-        right now for maps it only takes street/city/state/zip in for our links, are we cool staying there or should I make unit/floor/suite part of the search?
+        right now for maps it only takes street/city/state/zip in for our links, are we cool staying
+        there or should I make unit/floor/suite part of the search?
 
         Desi Gonzalez  12:31 PM
         I think that's cool, I wouldn't worry about it til we have evidence that that's a problem

--- a/src/components/Pages/Location/LocationInfo.js
+++ b/src/components/Pages/Location/LocationInfo.js
@@ -1,6 +1,8 @@
 import React, { Fragment } from 'react';
 import { capitalize } from 'lodash';
 import { useIntl } from 'react-intl';
+import { getEncodedLocation } from 'js/helpers/location';
+import { events as i18n } from 'js/i18n/definitions';
 
 import ResponsiveImage from 'components/ResponsiveImage';
 import { FULL_WIDTH_RESPONSIVE_IMAGE_SIZES } from 'js/helpers/constants';
@@ -57,12 +59,21 @@ const LocationPageContact = ({ phone, email }) => {
 
 const LocationPageAddress = ({ title, address }) => {
   const { street, city, state, zip } = address;
+  const intl = useIntl();
+  const encodedLocation = getEncodedLocation({ address });
   const AddressText = (
     <div>
       <span className="coa-LocationPage__address-line">{street}</span>
       <span className="coa-LocationPage__address-line">
         {city}, {state} {zip}
       </span>
+      <a
+        href={`//www.google.com/maps/search/?api=1&query=${encodedLocation}`}
+        className="coa-EventDetailItem__location-directions-link"
+        target="_blank"
+      >
+        {intl.formatMessage(i18n.getDirections)}
+      </a>
     </div>
   );
 

--- a/src/components/Pages/Location/LocationInfo.js
+++ b/src/components/Pages/Location/LocationInfo.js
@@ -2,7 +2,6 @@ import React, { Fragment } from 'react';
 import { capitalize } from 'lodash';
 import { useIntl } from 'react-intl';
 import { getEncodedLocation } from 'js/helpers/location';
-import { events as i18n } from 'js/i18n/definitions';
 
 import ResponsiveImage from 'components/ResponsiveImage';
 import { FULL_WIDTH_RESPONSIVE_IMAGE_SIZES } from 'js/helpers/constants';
@@ -12,6 +11,7 @@ import {
   date as i18nDate,
   locations as i18nLocations,
   contact as i18nContact,
+  misc as i18nMisc
 } from 'js/i18n/definitions';
 
 const LocationPageBlock = ({ title, content }) => (
@@ -60,7 +60,7 @@ const LocationPageContact = ({ phone, email }) => {
 const LocationPageAddress = ({ title, address }) => {
   const { street, city, state, zip } = address;
   const intl = useIntl();
-  const encodedLocation = getEncodedLocation({ address });
+  const encodedLocation = getEncodedLocation(address);
   const AddressText = (
     <div>
       <span className="coa-LocationPage__address-line">{street}</span>
@@ -69,10 +69,9 @@ const LocationPageAddress = ({ title, address }) => {
       </span>
       <a
         href={`//www.google.com/maps/search/?api=1&query=${encodedLocation}`}
-        className="coa-EventDetailItem__location-directions-link"
         target="_blank"
       >
-        {intl.formatMessage(i18n.getDirections)}
+        {intl.formatMessage(i18nMisc.getDirections)}
       </a>
     </div>
   );

--- a/src/js/i18n/definitions.js
+++ b/src/js/i18n/definitions.js
@@ -100,6 +100,7 @@ export const misc = defineMessages({
   contactInformation: 'Contact information',
   servicePageIsPartOfMessage: 'This service is a part of:',
   informationPageIsPartOfMessage: 'This information is a part of:',
+  getDirections: 'Get directions',
 });
 
 export const navigation = defineMessages({

--- a/src/js/i18n/locales/es.json
+++ b/src/js/i18n/locales/es.json
@@ -60,6 +60,7 @@
   "misc.contactInformation": "Información de contacto",
   "misc.servicePageIsPartOfMessage": "Este servicio es parte de:",
   "misc.informationPageIsPartOfMessage": "Esta información es parte de:",
+  "misc.getDirections": "Obtener direcciones",
   "navigation.home": "Inicio",
   "navigation.menu": "Menú",
   "navigation.openInNewWindow": "",


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Addresses on event pages have a little link that lets you open a google map in a new window. 

Locations and Department pages now get the same treatment. 

I moved the translated "get directions" into misc instead of using the same Events object just to keep clear in case we end up changing some of the microcopy in the future. 

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
   <!--- Netlify Example: `https://janis-<PR>.netlify.com/` --->  
https://janis-4059-link-maps.netlify.com/en/municipal-court/

# Checklist:
- [x] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
