### PR TITLE
3641 Set current language to html *lang* attribute tag

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,12 +3,18 @@ import { Root, Routes, useSiteData } from 'react-static';
 import { Route, Switch } from 'react-router';
 import { useIntl } from 'react-intl';
 import { LANG_URL_REGEX } from 'js/i18n/constants';
+import { Helmet } from "react-helmet"; // Helmet allows us to inject html attributes in the the document Header, body, and html tags.
 import CMSPreview from 'components/_Controllers/CMSPreview';
 import CMSLive from 'components/_Controllers/CMSLive';
 import I18nController from 'components/I18n/I18nController';
 import SkipToMain from 'components/PageSections/SkipToMain';
 import Header from 'components/PageSections/Header';
 import Footer from 'components/PageSections/Footer';
+
+const LANG_KEY = {
+  'en': 'en-US',
+  'es': 'es-001'
+}
 
 import 'css/coa.css';
 
@@ -45,6 +51,9 @@ const App = ({ navigation, threeoneone }) => {
               lang={props.match.params.lang}
               path={props.match.params.path}
             >
+              <Helmet
+                htmlAttributes={{ lang : LANG_KEY[props.match.params.lang] }}
+              />
               <Suspense fallback={<div>LOADING</div>}>
                 <AppView path={props.match.params.path || ''} />
               </Suspense>

--- a/src/App.js
+++ b/src/App.js
@@ -52,7 +52,7 @@ const App = ({ navigation, threeoneone }) => {
               path={props.match.params.path}
             >
               <Helmet
-                htmlAttributes={{ lang : LANG_KEY[props.match.params.lang] }}
+                htmlAttributes={{ lang : LANG_KEY[props.match.params.lang || "en"] }}
               />
               <Suspense fallback={<div>LOADING</div>}>
                 <AppView path={props.match.params.path || ''} />

--- a/static.config.js
+++ b/static.config.js
@@ -983,6 +983,10 @@ export default {
       //   template: 'src/components/Pages/Search', //TODO: update search page to be conscious of all languages
       // },
       {
+        path: 'es/',
+        // ...
+      },
+      {
         path: '404',
         template: 'src/components/Pages/404', //TODO: update 404 page to be conscious of all languages
       },

--- a/static.config.js
+++ b/static.config.js
@@ -983,10 +983,6 @@ export default {
       //   template: 'src/components/Pages/Search', //TODO: update search page to be conscious of all languages
       // },
       {
-        path: 'es/',
-        // ...
-      },
-      {
         path: '404',
         template: 'src/components/Pages/404', //TODO: update 404 page to be conscious of all languages
       },


### PR DESCRIPTION
ZenHub Issue: https://app.zenhub.com/workspaces/techstack-5a78b88e1ce69f3510b678ef/issues/cityofaustin/techstack/3641

Deployed:  https://janis-3641-lang-tag.netlify.com/

# Description
<!--- include a summary of the change and what it fixes. -->

While our UI has been translating between es/en for awhile now. We haven't been updating the html for screen readers and google analytics. 

This will do that! 

See `Research` for more info(this has been noted in issue as well)

# Types of changes
- [x] New feature (non-breaking change which adds functionality)

# How can this be tested?
- Visit:  https://janis-3641-lang-tag.netlify.com/
- Inspect HTML element:
- toggle english / spanish: does the `<html lang=` change?

<img width="418" alt="Screen Shot 2020-03-12 at 4 29 32 PM" src="https://user-images.githubusercontent.com/15821138/76568502-f6f30500-647e-11ea-9e7e-1c0055e507f5.png">
<img width="445" alt="Screen Shot 2020-03-12 at 4 29 46 PM" src="https://user-images.githubusercontent.com/15821138/76568504-f78b9b80-647e-11ea-8d45-2e22ee78d381.png">



# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub

----
# Research 

I’m currently setting up language tracking on Janis with google analytics.

And, currently, we set our English language to `en-US`
- English as spoken in the United States.

For español, we haven’t added it for tracking yet. And, like English, we can specify the region. Here are some examples...
- `es` alone is “Spanish, Castilian”
- `es-001 `is “World”
-`es-mx` is “Mexico”
- `es-003` “North America” includes Caribbean(es-029), Central America(es-013)
- `es-021` “North America” does NOT include Caribbean(es-029), Central America(es-013)

### What should we set it to?   
-  (*can be modified changed later)

This setting would be how we set our html lang tag when español is toggled. Allowing google analytics to track that.

But, perhaps most importantly, screen readers now and in the future could use this info differently.

I’m sure y’all are curious and here is where you can see more info and options.
- Language subtag lookup: https://r12a.github.io/app-subtags/

### A thing to keep in mind…

- A resident can set their language on their browser.
- Making it more specific/different then what has been given to them...
- Like:  “Ok austin.alpha.gov, that’s great you want to give me es-mx, but I’m gonna go ahead and translate to ex-029.
- We can’t control this.

<img width="1148" alt="Screen Shot 2020-03-11 at 12 11 32 PM" src="https://user-images.githubusercontent.com/15821138/76456510-187fbe00-63a5-11ea-96c9-c49c89d1dbef.png">

Check this out! It’s our 2020 language data so far...
- At this point, we’ve only told the browser that the site is en-US
- Yet, we’re getting a lot of different language results that are reflecting browser language settings. Cool!

🤔What is `es-419`, may you ponder ? ... “latin america and the caribbean English”. WAY cool!
