### PR TITLE
4158 Implement COVID-19 hours alert on location pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,6 @@ import Footer from 'components/PageSections/Footer';
 import Alert from 'components/Alerts';
 import { alert as i18n1 } from 'js/i18n/definitions';
 
-
 const LANG_KEY = {
   'en': 'en-US',
   'es': 'es-001'
@@ -41,11 +40,13 @@ const AppView = ({path}) => {
     <div>
       <SkipToMain />
       <Header navigation={navigation[intl.locale]} path={path} />
+      {/* START ⚠️COVED_19 Hardcoded */}
       <Alert
         badge="Coronavirus (COVID-19)"
         link="https://www.austintexas.gov/COVID19"
         linkContent={intl.formatMessage(i18n1.getLatest)}
       />
+      {/* END ⚠️COVED_19 Hardcoded */}
       <main role="main" id="main">
         <ScrollToTop />
         <Switch>

--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,9 @@ import I18nController from 'components/I18n/I18nController';
 import SkipToMain from 'components/PageSections/SkipToMain';
 import Header from 'components/PageSections/Header';
 import Footer from 'components/PageSections/Footer';
-import HomepageAlert from 'components/HomepageAlert';
+import Alert from 'components/Alerts';
+import { alert as i18n1 } from 'js/i18n/definitions';
+
 
 const LANG_KEY = {
   'en': 'en-US',
@@ -39,7 +41,11 @@ const AppView = ({path}) => {
     <div>
       <SkipToMain />
       <Header navigation={navigation[intl.locale]} path={path} />
-      <HomepageAlert/>
+      <Alert
+        badge="Coronavirus (COVID-19)"
+        link="https://www.austintexas.gov/COVID19"
+        linkContent={intl.formatMessage(i18n1.getLatest)}
+      />
       <main role="main" id="main">
         <ScrollToTop />
         <Switch>

--- a/src/components/Alerts/_Alerts.scss
+++ b/src/components/Alerts/_Alerts.scss
@@ -1,11 +1,16 @@
 .coa-HomepageAlert__container {
   background-color: #ffbe2e;
-  height: 159px;
+  padding-bottom: 2rem;
   @include media($coa-medium-screen) {
-    height: 64px;
+    padding-bottom: 0rem;
     padding-left: 2rem;
     padding-right: 2rem;
   }
+}
+
+.coa-HomepageAlert__container.textContent {
+  padding: 15px 24px 24px 24px;
+  margin-bottom: 20px;
 }
 
 .coa-HomepageAlert__content {
@@ -79,4 +84,10 @@
   font-size: 16px;
   position: relative;
   top: 3px;
+}
+
+.coa-HomepageAlert__label--text-content {
+  font-size: 18px;
+  line-height: 26px;
+  padding-top: 5px;
 }

--- a/src/components/Alerts/_Alerts.scss
+++ b/src/components/Alerts/_Alerts.scss
@@ -9,7 +9,7 @@
 }
 
 .coa-HomepageAlert__container.textContent {
-  padding: 15px 24px 24px 24px;
+  padding: 15px 30px 24px 24px;
   margin-bottom: 20px;
 }
 

--- a/src/components/Alerts/index.js
+++ b/src/components/Alerts/index.js
@@ -20,9 +20,7 @@ const Alert = ({ badge, content, link, linkContent }) => {
             </div>
             <span className="coa-HomepageAlert__label--text"> {badge} </span>
           </div>
-
         </div>
-
         <div className="coa-HomepageAlert__link">
         { !styleWithContent && (
           <a
@@ -35,7 +33,6 @@ const Alert = ({ badge, content, link, linkContent }) => {
             <i className="material-icons coa-HomepageAlert__link-icon">open_in_new</i>
           </a>
         )}
-
         </div>
       </div>
       { (content == "locationsCOVID_19") && (

--- a/src/components/Alerts/index.js
+++ b/src/components/Alerts/index.js
@@ -2,42 +2,53 @@ import React from 'react';
 import { useIntl } from 'react-intl';
 import { alert as i18n1 } from 'js/i18n/definitions';
 import ExternalLink from 'components/ExternalLink';
+import LocationsCOVID_19 from 'components/Alerts/locationsCOVID_19.js';
 
-
-const HomepageAlert = ({ }) => {
+const Alert = ({ badge, content, link, linkContent }) => {
+  const styleWithContent = content ? "textContent" : ""
   const intl = useIntl();
 
   return (
-    <div className="coa-HomepageAlert__container">
+    <div className={"coa-HomepageAlert__container "+styleWithContent}>
       <div className="coa-HomepageAlert__content">
         <div className="coa-HomepageAlert__label">
           <div className="coa-HomepageAlert__label--content">
-            <div className="coa-HomepageAlert__label--icon"> 
-              <i class="material-icons">
+            <div className="coa-HomepageAlert__label--icon">
+              <i className="material-icons">
                 error_outline
               </i>
             </div>
-            <span className="coa-HomepageAlert__label--text"> Coronavirus (COVID-19) </span>
+            <span className="coa-HomepageAlert__label--text"> {badge} </span>
           </div>
+
         </div>
+
         <div className="coa-HomepageAlert__link">
+        { !styleWithContent && (
           <a
-            href="https://www.austintexas.gov/COVID19"
+            href={link}
             className="coa-HomepageAlert__link-external"
             target="_blank"
             rel="noopener noreferrer"
           >
-            {intl.formatMessage(i18n1.getLatest)}
+            {linkContent}
             <i className="material-icons coa-HomepageAlert__link-icon">open_in_new</i>
           </a>
+        )}
+
         </div>
       </div>
+      { (content == "locationsCOVID_19") && (
+        <div className="coa-HomepageAlert__label--text-content">
+          <LocationsCOVID_19 />
+        </div>
+      )}
     </div>
   )
 };
 
 
-export default HomepageAlert;
+export default Alert;
 
 
 /*
@@ -46,4 +57,4 @@ element.style {
     top: 10px;
     position: relative;
     left: 10px;
-}*/ 
+}*/

--- a/src/components/Alerts/locationsCOVID_19.js
+++ b/src/components/Alerts/locationsCOVID_19.js
@@ -8,11 +8,11 @@ const LocationsCOVID_19 = () => {
   return (
     <div>
 
-      { ( lang=="en" ) && (<>
+      { ( lang === "en" ) && (<>
         City of Austin offices and facilities may be closed or have temporary
         emergency hours that are not up to date on this website.&nbsp;
       </>)}
-      { ( lang=="es" ) && (<>
+      { ( lang === "es" ) && (<>
         Las oficinas e instalaciones de la Ciudad de Austin quizás estén cerradas
         o tengan horario de emergencia temporal que no se ha actualizado
         en este sitio web. &nbsp;
@@ -22,12 +22,12 @@ const LocationsCOVID_19 = () => {
         href='tel:15129742000'
         className="coa-HomepageAlert__link-external"
       >
-        { ( lang=="en" ) && (<>Call 3-1-1</>)}
-        { ( lang=="es" ) && (<>Llame al 3-1-1</>)}
+        { ( lang === "en" ) && (<>Call 3-1-1</>)}
+        { ( lang === "es" ) && (<>Llame al 3-1-1</>)}
       </a>
 
-      { ( lang=="en" ) && (<>&nbsp;for updated hours information or&nbsp;</>)}
-      { ( lang=="es" ) && (<>&nbsp;para información actualizada sobre horarios o&nbsp;</>)}
+      { ( lang === "en" ) && (<>&nbsp;for updated hours information or&nbsp;</>)}
+      { ( lang === "es" ) && (<>&nbsp;para información actualizada sobre horarios o&nbsp;</>)}
 
       <a
         href="https://www.austintexas.gov/COVID19"
@@ -35,8 +35,8 @@ const LocationsCOVID_19 = () => {
         target="_blank"
         rel="noopener noreferrer"
       >
-        { ( lang=="en" ) && (<>get current information about coronavirus (COVID-19) in Austin.</>)}
-        { ( lang=="es" ) && (<>obtenga información actual sobre el coronavirus (COVID-19) en Austin.</>)}
+        { ( lang === "en" ) && (<>get current information about coronavirus (COVID-19) in Austin.</>)}
+        { ( lang === "es" ) && (<>obtenga información actual sobre el coronavirus (COVID-19) en Austin.</>)}
 
         <i className="material-icons coa-HomepageAlert__link-icon">open_in_new</i>
       </a>

--- a/src/components/Alerts/locationsCOVID_19.js
+++ b/src/components/Alerts/locationsCOVID_19.js
@@ -3,7 +3,7 @@ import { useIntl } from 'react-intl';
 import { alert as i18n1 } from 'js/i18n/definitions';
 import ExternalLink from 'components/ExternalLink';
 
-const LocationsCOVID_19 = (x) => {
+const LocationsCOVID_19 = () => {
   const lang = useIntl().locale;
   return (
     <div>

--- a/src/components/Alerts/locationsCOVID_19.js
+++ b/src/components/Alerts/locationsCOVID_19.js
@@ -19,7 +19,7 @@ const LocationsCOVID_19 = (x) => {
       </>)}
 
       <a
-        href='tel:311'
+        href='tel:15129742000'
         className="coa-HomepageAlert__link-external"
       >
         { ( lang=="en" ) && (<>Call 3-1-1</>)}

--- a/src/components/Alerts/locationsCOVID_19.js
+++ b/src/components/Alerts/locationsCOVID_19.js
@@ -3,27 +3,41 @@ import { useIntl } from 'react-intl';
 import { alert as i18n1 } from 'js/i18n/definitions';
 import ExternalLink from 'components/ExternalLink';
 
-const LocationsCOVID_19 = (props) => {
-  console.log("props :", props)
+const LocationsCOVID_19 = (x) => {
+  const lang = useIntl().locale;
   return (
     <div>
-      City of Austin offices and facilities may be closed or
-      have temporary emergency hours that are not up to date on this
-      website.&nbsp;
+
+      { ( lang=="en" ) && (<>
+        City of Austin offices and facilities may be closed or have temporary
+        emergency hours that are not up to date on this website.&nbsp;
+      </>)}
+      { ( lang=="es" ) && (<>
+        Es posible que oficinas y servicios de la Ciudad de Austin estén cerrados
+        o tengan horarios de emergencia temporales que no están actualizados en
+        este sitio. &nbsp;
+      </>)}
+
       <a
         href='tel:311'
         className="coa-HomepageAlert__link-external"
       >
-        Call 3-1-1
+        { ( lang=="en" ) && (<>Call 3-1-1</>)}
+        { ( lang=="es" ) && (<>Llame al 3-1-1</>)}
       </a>
-      &nbsp;for updated hours information or&nbsp;
+
+      { ( lang=="en" ) && (<>&nbsp;for updated hours information or&nbsp;</>)}
+      { ( lang=="es" ) && (<>&nbsp;para obtener horarios actualizados u&nbsp;</>)}
+
       <a
         href="https://www.austintexas.gov/COVID19"
         className="coa-HomepageAlert__link-external"
         target="_blank"
         rel="noopener noreferrer"
       >
-        get current information about coronavirus (COVID-19) in Austin.
+        { ( lang=="en" ) && (<>get current information about coronavirus (COVID-19) in Austin.</>)}
+        { ( lang=="es" ) && (<>obtenga información actual sobre el coronavirus (COVID-19) en Austin.</>)}
+
         <i className="material-icons coa-HomepageAlert__link-icon">open_in_new</i>
       </a>
     </div>

--- a/src/components/Alerts/locationsCOVID_19.js
+++ b/src/components/Alerts/locationsCOVID_19.js
@@ -13,9 +13,9 @@ const LocationsCOVID_19 = (x) => {
         emergency hours that are not up to date on this website.&nbsp;
       </>)}
       { ( lang=="es" ) && (<>
-        Es posible que oficinas y servicios de la Ciudad de Austin estén cerrados
-        o tengan horarios de emergencia temporales que no están actualizados en
-        este sitio. &nbsp;
+        Las oficinas e instalaciones de la Ciudad de Austin quizás estén cerradas
+        o tengan horario de emergencia temporal que no se ha actualizado
+        en este sitio web. &nbsp;
       </>)}
 
       <a
@@ -27,7 +27,7 @@ const LocationsCOVID_19 = (x) => {
       </a>
 
       { ( lang=="en" ) && (<>&nbsp;for updated hours information or&nbsp;</>)}
-      { ( lang=="es" ) && (<>&nbsp;para obtener horarios actualizados u&nbsp;</>)}
+      { ( lang=="es" ) && (<>&nbsp;para información actualizada sobre horarios o&nbsp;</>)}
 
       <a
         href="https://www.austintexas.gov/COVID19"

--- a/src/components/Alerts/locationsCOVID_19.js
+++ b/src/components/Alerts/locationsCOVID_19.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useIntl } from 'react-intl';
+import { alert as i18n1 } from 'js/i18n/definitions';
+import ExternalLink from 'components/ExternalLink';
+
+const LocationsCOVID_19 = (props) => {
+  console.log("props :", props)
+  return (
+    <div>
+      City of Austin offices and facilities may be closed or
+      have temporary emergency hours that are not up to date on this
+      website.&nbsp;
+      <a
+        href='tel:311'
+        className="coa-HomepageAlert__link-external"
+      >
+        Call 3-1-1
+      </a>
+      &nbsp;for updated hours information or&nbsp;
+      <a
+        href="https://www.austintexas.gov/COVID19"
+        className="coa-HomepageAlert__link-external"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        get current information about coronavirus (COVID-19) in Austin.
+        <i className="material-icons coa-HomepageAlert__link-icon">open_in_new</i>
+      </a>
+    </div>
+  )
+}
+
+export default LocationsCOVID_19;

--- a/src/components/Pages/Location/LocationInfo.js
+++ b/src/components/Pages/Location/LocationInfo.js
@@ -163,9 +163,15 @@ const LocationPageFacilityHours = ({ hours }) => {
       <h2 className="coa-LocationPage__sub-section-title">
         {intl.formatMessage(i18nLocations.facilityHours)}
       </h2>
+
+
       <h4 style={{backgroundColor: "yellow"}}>
         ⚠️Due to Coronavirus(COVID_19) closures, these hours may be effected.
+        <a href="https://austintexas.gov/COVID19">Get current informaiton about Coronavirus(COVID_19) in Austin</a>
       </h4>
+
+
+      
       <div className="coa-LocationPage__sub-section-block-container coa-LocationPage__sub-section-block-container__hours">
         <LocationPageBlock
           title={intl.formatMessage(i18nLocations.standardHours)}

--- a/src/components/Pages/Location/LocationInfo.js
+++ b/src/components/Pages/Location/LocationInfo.js
@@ -163,6 +163,9 @@ const LocationPageFacilityHours = ({ hours }) => {
       <h2 className="coa-LocationPage__sub-section-title">
         {intl.formatMessage(i18nLocations.facilityHours)}
       </h2>
+      <h4 style={{backgroundColor: "yellow"}}>
+        ⚠️Due to Coronavirus(COVID_19) closures, these hours may be effected.
+      </h4>
       <div className="coa-LocationPage__sub-section-block-container coa-LocationPage__sub-section-block-container__hours">
         <LocationPageBlock
           title={intl.formatMessage(i18nLocations.standardHours)}

--- a/src/components/Pages/Location/LocationInfo.js
+++ b/src/components/Pages/Location/LocationInfo.js
@@ -12,8 +12,7 @@ import {
   date as i18nDate,
   locations as i18nLocations,
   contact as i18nContact,
-  misc as i18nMisc,
-  alert as i18n1
+  misc as i18nMisc
 } from 'js/i18n/definitions';
 
 const LocationPageBlock = ({ title, content }) => (
@@ -160,47 +159,17 @@ const LocationPageFacilityHours = ({ hours }) => {
     </div>
   );
 
-  const alertContent = () => {
-    // console.log("props :", props)
-    return (
-      <div>
-      City of Austin offices and facilities may be closed or
-      have temporary emergency hours that are not up to date on this
-      website.&nbsp;
-      <a
-        href='tel:311'
-        className="coa-HomepageAlert__link-external"
-      >
-        Call 3-1-1
-      </a>
-      &nbsp;for updated hours information or&nbsp;
-      <a
-        href="https://www.austintexas.gov/COVID19"
-        className="coa-HomepageAlert__link-external"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        get current information about coronavirus (COVID-19) in Austin.
-        <i className="material-icons coa-HomepageAlert__link-icon">open_in_new</i>
-      </a>
-    </div>
-  )}
-
   return (
     <div className="coa-LocationPage__sub-section">
       <h2 className="coa-LocationPage__sub-section-title">
         {intl.formatMessage(i18nLocations.facilityHours)}
       </h2>
-      {/* START
-        ⚠️COVED_19 Hardcoded HACK
-      */}
+      {/* START ⚠️COVED_19 Hardcoded */}
       <Alert
         badge="Coronavirus (COVID-19)"
         content="locationsCOVID_19"
       />
-      {/*
-        ⚠️COVED_19 Hardcoded HACK
-      END */}
+      {/* END ⚠️COVED_19 Hardcoded */}
       <div className="coa-LocationPage__sub-section-block-container coa-LocationPage__sub-section-block-container__hours">
         <LocationPageBlock
           title={intl.formatMessage(i18nLocations.standardHours)}

--- a/src/components/Pages/Location/LocationInfo.js
+++ b/src/components/Pages/Location/LocationInfo.js
@@ -6,12 +6,14 @@ import { getEncodedLocation } from 'js/helpers/location';
 import ResponsiveImage from 'components/ResponsiveImage';
 import { FULL_WIDTH_RESPONSIVE_IMAGE_SIZES } from 'js/helpers/constants';
 import getImageData from 'components/ResponsiveImage/getImageData';
+import Alert from 'components/Alerts';
 import { getDaysInOrder } from 'js/helpers/date';
 import {
   date as i18nDate,
   locations as i18nLocations,
   contact as i18nContact,
-  misc as i18nMisc
+  misc as i18nMisc,
+  alert as i18n1
 } from 'js/i18n/definitions';
 
 const LocationPageBlock = ({ title, content }) => (
@@ -158,20 +160,47 @@ const LocationPageFacilityHours = ({ hours }) => {
     </div>
   );
 
+  const alertContent = () => {
+    // console.log("props :", props)
+    return (
+      <div>
+      City of Austin offices and facilities may be closed or
+      have temporary emergency hours that are not up to date on this
+      website.&nbsp;
+      <a
+        href='tel:311'
+        className="coa-HomepageAlert__link-external"
+      >
+        Call 3-1-1
+      </a>
+      &nbsp;for updated hours information or&nbsp;
+      <a
+        href="https://www.austintexas.gov/COVID19"
+        className="coa-HomepageAlert__link-external"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        get current information about coronavirus (COVID-19) in Austin.
+        <i className="material-icons coa-HomepageAlert__link-icon">open_in_new</i>
+      </a>
+    </div>
+  )}
+
   return (
     <div className="coa-LocationPage__sub-section">
       <h2 className="coa-LocationPage__sub-section-title">
         {intl.formatMessage(i18nLocations.facilityHours)}
       </h2>
-
-
-      <h4 style={{backgroundColor: "yellow"}}>
-        ⚠️Due to Coronavirus(COVID_19) closures, these hours may be effected.
-        <a href="https://austintexas.gov/COVID19">Get current informaiton about Coronavirus(COVID_19) in Austin</a>
-      </h4>
-
-
-      
+      {/* START
+        ⚠️COVED_19 Hardcoded HACK
+      */}
+      <Alert
+        badge="Coronavirus (COVID-19)"
+        content="locationsCOVID_19"
+      />
+      {/*
+        ⚠️COVED_19 Hardcoded HACK
+      END */}
       <div className="coa-LocationPage__sub-section-block-container coa-LocationPage__sub-section-block-container__hours">
         <LocationPageBlock
           title={intl.formatMessage(i18nLocations.standardHours)}

--- a/src/css/coa.scss
+++ b/src/css/coa.scss
@@ -73,4 +73,4 @@
 @import 'components/Pages/Event';
 @import 'components/Pages/EventList';
 @import 'components/PageSections/EventsHomePage/EventsHomePage';
-@import 'components/HomepageAlert/HomepageAlert';
+@import 'components/Alerts/Alerts';

--- a/src/js/i18n/locales/es.json
+++ b/src/js/i18n/locales/es.json
@@ -140,5 +140,5 @@
   "events.noon": "Mediodía",
   "events.upcoming": "Próximos eventos",
   "events.viewAll": "Ver todos los eventos",
-  "alert.getLatest": "Obtenga informácion actual sobre el coronavirus (COVID-19) en Austin"
+  "alert.getLatest": "Obtenga información actual sobre el coronavirus (COVID-19) en Austin"
 }


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->
ZENHUB LINK: https://app.zenhub.com/workspaces/techstack-5a78b88e1ce69f3510b678ef/issues/cityofaustin/techstack/4158

# Description

This will add a unique COVID-19 alert to all the location pages.

# Types of changes
- [x] New feature (non-breaking change which adds functionality)

# How can this be tested?

See Design: https://app.abstract.com/projects/065fcabf-a46a-4688-a858-83ce2117b16c/branches/8b432790-fc84-4a1d-a585-4695551946a9/collections/7925c82e-84e9-4924-926a-aed1c42e308e

Deployed: 
- https://janis-hard-coded-hours-alert.netlify.com/
- Direct Example: https://janis-hard-coded-hours-alert.netlify.com/en/location/recycle-reuse-drop-off-center/

Use 👇 below links and check for ...  
- styles and 
- external links to https://www.austintexas.gov/COVID19
- 311 calls > (512) 974-2000. 
- Toggle 'es'/'en' ... ☝️repeat.

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
