### PR TITLE
3899 broken build with top level service pages

### DIFF
--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -34,8 +34,8 @@ const branchOverrides = {
   '3244-guide-icon-tiles': {
     CMS_API: 'https://joplin-pr-3244-guide-icon-tile.herokuapp.com/api/graphql'
   },
-  '4042-unpub-page': {
-    CMS_API: 'https://joplin-pr-4042-unpub-page.herokuapp.com/api/graphql'
+  '3899-broken-build': {
+    CMS_API: 'https://joplin-pr-3899-broken-build.herokuapp.com/api/graphql'
   }
 };
 

--- a/src/components/Pages/Service.js
+++ b/src/components/Pages/Service.js
@@ -109,7 +109,7 @@ const Service = ({ service, intl }) => {
             )}
           </div>
         </div>
-        {!coaGlobal && 
+        {//!coaGlobal && 
           <RelatedToMobile
             relatedTo={contextualNavData.relatedTo}
             offeredBy={contextualNavData.offeredBy}

--- a/src/components/Pages/Service.js
+++ b/src/components/Pages/Service.js
@@ -109,10 +109,12 @@ const Service = ({ service, intl }) => {
             )}
           </div>
         </div>
-        <RelatedToMobile
-          relatedTo={contextualNavData.relatedTo}
-          offeredBy={contextualNavData.offeredBy}
-        />
+        {!coaGlobal && 
+          <RelatedToMobile
+            relatedTo={contextualNavData.relatedTo}
+            offeredBy={contextualNavData.offeredBy}
+          />
+        }
       </div>
       <UserFeedback />
     </div>

--- a/src/components/Pages/Service.js
+++ b/src/components/Pages/Service.js
@@ -109,7 +109,7 @@ const Service = ({ service, intl }) => {
             )}
           </div>
         </div>
-        {//!coaGlobal && 
+        {!coaGlobal && 
           <RelatedToMobile
             relatedTo={contextualNavData.relatedTo}
             offeredBy={contextualNavData.offeredBy}

--- a/src/js/queries/servicePageFragment.js
+++ b/src/js/queries/servicePageFragment.js
@@ -4,6 +4,7 @@ const servicePageFragment = `
   fragment servicePageInfo on ServicePageNode {
     id
     title
+    coaGlobal
     departments {
       id
       title


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Top level service pages were breaking builds because we didn't actually check if they were marked as `coaGlobal` or not. 

Thanks to Brian for pointing me in the right direction. 

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
https://joplin-pr-3899-broken-build.herokuapp.com/

the janis: https://janis-3899-broken-build.netlify.com/

The build failures and eventual success: https://app.netlify.com/sites/janis-3899-broken-build/deploys

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
