### PR TITLE
4325 site struct

### DIFF
--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -31,7 +31,7 @@ const branchOverrides = {
     joplin_appname: 'joplin-pr-3690-incremental',
     REACT_STATIC_PREFETCH_RATE: '10',
 },
-  '4322-janis-contacts': {
+  '4325-site-struct': {
     joplin_appname: 'joplin-pr-import-everything'
   },
   '4289-page-guide': {

--- a/src/js/helpers/cleanData.js
+++ b/src/js/helpers/cleanData.js
@@ -291,8 +291,7 @@ export const cleanLinks = (links, pageType) => {
     const link = edge.node;
 
     // Check for global
-    //chia put this back, this is for local build
-    if (!link.coaGlobal) {
+    if (link.coaGlobal) {
       link.text = link.title;
 
       // If we end up with a global page as a top service on the home page

--- a/src/js/helpers/cleanData.js
+++ b/src/js/helpers/cleanData.js
@@ -89,8 +89,10 @@ export const cleanContact = contact => {
 };
 
 export const cleanLocationPageJanisUrl = janisUrl => {
-  // quick fix for urls until we get localized urls working in joplin
-  return `/${janisUrl.split('/en/')[1]}`;
+  if(!!janisUrl.length){
+    return janisUrl[0];
+  }
+  return '/';
 };
 
 /*
@@ -192,13 +194,14 @@ export const cleanLocationPage = locationPage => {
       title: edge.node.relatedService.title,
       exceptions: edge.node.relatedService.hoursExceptions,
       hoursSameAsLocation: edge.node.hoursSameAsLocation,
+      //janisUrl is an array of urls, checks to see if there is length and if so takes the 1st one
       url: cleanLocationPageJanisUrl(edge.node.relatedService.janisUrl),
       phones:
-        edge.node.relatedService.contacts.edges.length &&
-        edge.node.relatedService.contacts.edges[0].node.contact.phoneNumber.edges.map(
+        edge.node.relatedService.contact &&
+        edge.node.relatedService.contact.phoneNumbers &&
+        edge.node.relatedService.contact.phoneNumbers.edges.map(
           phoneEdge => {
             return {
-              // why do we call phoneDescription label here,
               label: phoneEdge.node.phoneDescription,
               number: parsePhoneNumberFromString(
                 phoneEdge.node.phoneNumber,

--- a/static.config.js
+++ b/static.config.js
@@ -737,10 +737,8 @@ const makeAllPages = async (langCode, incrementalPageId) => {
         ),
       );
     }
-    //if (!pageAtUrlInfo.node.janisUrls.length) {
-      // console.log(pageAtUrlInfo.node)
-    //}
-    // not all pages have instances
+
+    // not all pages have instances (events and locations not under departments)
     return Promise.all(
       pageAtUrlInfo.node.janisUrls.map(instanceOfPage =>
         buildPageAtUrl(

--- a/static.config.js
+++ b/static.config.js
@@ -725,6 +725,7 @@ const makeAllPages = async (langCode, incrementalPageId) => {
 
   let allPages = await Promise.all(
     pages.map(pageAtUrlInfo => {
+      if (!!pageAtUrlInfo.node.janisInstances.length) {
       return Promise.all(
         pageAtUrlInfo.node.janisInstances.map(instanceOfPage =>
           buildPageAtUrl(
@@ -735,6 +736,21 @@ const makeAllPages = async (langCode, incrementalPageId) => {
           ),
         ),
       );
+    }
+    //if (!pageAtUrlInfo.node.janisUrls.length) {
+      // console.log(pageAtUrlInfo.node)
+    //}
+    // not all pages have instances
+    return Promise.all(
+      pageAtUrlInfo.node.janisUrls.map(instanceOfPage =>
+        buildPageAtUrl(
+          pageAtUrlInfo.node,
+          instanceOfPage,
+          client,
+          pagesOfGuidesData,
+        ),
+      ),
+    );
     }),
   );
 


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Adding pages that dont have janisInstances (but do have janisUrls) to the site structure.

There are still pages that don't have instances or urls, They don't have departments nor topics assigned. They aren't being added to the site structure because they have no place in the hierarchy. (for example https://joplin-pr-import-everything.herokuapp.com/admin/pages/156/edit/#tab-content)

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
   <!--- Netlify Example: `https://janis-<PR>.netlify.com/` --->  

https://janis-v3-4325-site-struct.netlify.app/

check the events at the bottom of the page. click one, confirm it loads. Click a location within that page, confirm it loads. 

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
