### PR TITLE
use new CMS_MEDIA

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = async ({ config, mode }) => {
   config.plugins.push(
     new webpack.DefinePlugin({
       'process.env': {
-        "CMS_MEDIA": JSON.stringify("https://joplin-austin-gov-static.s3.amazonaws.com/staging/media"),
+        "CMS_MEDIA": JSON.stringify("https://joplin3-austin-gov-static.s3.amazonaws.com/staging/media"),
       }
     })
   );

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -29,7 +29,7 @@ ARG CMS_MEDIA
 ENV CMS_MEDIA=${CMS_MEDIA:-https://joplin-austin-gov.s3.amazonaws.com/media}
 
 ARG CMS_DOCS
-ENV CMS_DOCS=${CMS_DOCS:-https://joplin-austin-gov-static.s3.amazonaws.com/production/media/documents}
+ENV CMS_DOCS=${CMS_DOCS:-https://joplin3-austin-gov-static.s3.amazonaws.com/production/media/documents}
 
 COPY public /app/public
 COPY src /app/src

--- a/cypress/integration/cms_media.spec.js
+++ b/cypress/integration/cms_media.spec.js
@@ -8,6 +8,6 @@ describe('Testing that document/pdf urls contain a valid path', () => {
       .eq(3)
       .find('a')
       .should('have.attr', 'href')
-      .and('match', /joplin-austin-gov-static.s3.amazonaws.com/)
+      .and('match', /joplin3-austin-gov-static.s3.amazonaws.com/)
 	})
 })

--- a/package.json
+++ b/package.json
@@ -81,9 +81,9 @@
   },
   "scripts": {
     "start-local": "./scripts/serve-local.sh",
-    "start-joplin-prod": "NODE_PATH=./src CMS_API='http://joplin.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='https://joplin-austin-gov-static.s3.amazonaws.com/production/media/documents' npm-run-all -p watch-css start-js",
-    "start-joplin-staging": "NODE_PATH=./src CMS_API='http://joplin-staging.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='multiple' npm-run-all -p watch-css start-js",
-    "start-joplin-pr": "NODE_PATH=./src CMS_API='https://joplin-pr-4340-official-docume.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='multiple' npm-run-all -p watch-css start-js",
+    "start-joplin-prod": "NODE_PATH=./src CMS_API='http://joplin.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin3-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='https://joplin3-austin-gov-static.s3.amazonaws.com/production/media/documents' npm-run-all -p watch-css start-js",
+    "start-joplin-staging": "NODE_PATH=./src CMS_API='http://joplin-staging.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin3-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='multiple' npm-run-all -p watch-css start-js",
+    "start-joplin-pr": "NODE_PATH=./src CMS_API='https://joplin-pr-4340-official-docume.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin3-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='multiple' npm-run-all -p watch-css start-js",
     "start-joplin-local": "NODE_PATH=./src CMS_API='http://127.0.0.1:8000/api/graphql' CMS_MEDIA='http://127.0.0.1:8000/media' CMS_DOCS='multiple' npm-run-all -p watch-css start-js",
     "start-staging": "./scripts/serve-local.sh -S",
     "start-prod": "./scripts/serve-local.sh -P",

--- a/scripts/build-full-local.sh
+++ b/scripts/build-full-local.sh
@@ -7,8 +7,8 @@
 # - export CMS_MEDIA='https://joplin-pr-3244-guide-icon-tile.herokuapp.com/media'
 
 # Or,  maybe you want to use staging or production media
-# - Staging Media: `https://joplin-austin-gov-static.s3.amazonaws.com/staging/media`
-# - Production Media: `https://joplin-austin-gov-static.s3.amazonaws.com/production/media`
+# - Staging Media: `https://joplin3-austin-gov-static.s3.amazonaws.com/staging/media`
+# - Production Media: `https://joplin3-austin-gov-static.s3.amazonaws.com/production/media`
 
 export NODE_PATH='./src'
 

--- a/scripts/build-full.sh
+++ b/scripts/build-full.sh
@@ -7,13 +7,13 @@
 # - export CMS_MEDIA='https://joplin-pr-3244-guide-icon-tile.herokuapp.com/media'
 
 # Or,  maybe you want to use staging or production media
-# - Staging Media: `https://joplin-austin-gov-static.s3.amazonaws.com/staging/media`
-# - Production Media: `https://joplin-austin-gov-static.s3.amazonaws.com/production/media`
+# - Staging Media: `https://joplin3-austin-gov-static.s3.amazonaws.com/staging/media`
+# - Production Media: `https://joplin3-austin-gov-static.s3.amazonaws.com/production/media`
 
 export NODE_PATH='./src'
 
 export CMS_API='https://joplin-staging.herokuapp.com/api/graphql'
-export CMS_MEDIA='https://joplin-austin-gov-static.s3.amazonaws.com/staging/media'
+export CMS_MEDIA='https://joplin3-austin-gov-static.s3.amazonaws.com/staging/media'
 
 yarn npm-run-all build-css build-js
 

--- a/scripts/serve-local.sh
+++ b/scripts/serve-local.sh
@@ -39,20 +39,20 @@ while getopts "PSe:M:A:" opt; do
   case $opt in
     P )
       CMS_API="https://joplin.herokuapp.com/api/graphql"
-      CMS_MEDIA="https://joplin-austin-gov-static.s3.amazonaws.com/production/media"
+      CMS_MEDIA="https://joplin3-austin-gov-static.s3.amazonaws.com/production/media"
       ;;
     S)
       CMS_API="https://joplin-staging.herokuapp.com/api/graphql"
-      CMS_MEDIA="https://joplin-austin-gov-static.s3.amazonaws.com/staging/media"
+      CMS_MEDIA="https://joplin3-austin-gov-static.s3.amazonaws.com/staging/media"
       ;;
     e )
       EXEC=$OPTARG
       ;;
     M )
       if [ "$OPTARG" == "prod" ]; then
-        CMS_MEDIA="https://joplin-austin-gov-static.s3.amazonaws.com/production/media"
+        CMS_MEDIA="https://joplin3-austin-gov-static.s3.amazonaws.com/production/media"
       elif [ "$OPTARG" == "staging" ]; then
-        CMS_MEDIA="https://joplin-austin-gov-static.s3.amazonaws.com/staging/media"
+        CMS_MEDIA="https://joplin3-austin-gov-static.s3.amazonaws.com/staging/media"
       else
         CMS_MEDIA=$OPTARG
       fi

--- a/scripts/undockered.sh
+++ b/scripts/undockered.sh
@@ -6,7 +6,7 @@ CD=`dirname $BASH_SOURCE`
 # Set Env vars
 NODE_PATH=$CD/../src
 CMS_API='http://localhost:8000/api/graphql' # Local API
-CMS_MEDIA='https://joplin-austin-gov-static.s3.amazonaws.com/production/media' # Prod images
+CMS_MEDIA='https://joplin3-austin-gov-static.s3.amazonaws.com/production/media' # Prod images
 
 # Process Parameters
 # if -P prod flag is used, then point to prod graphql and CMS
@@ -14,20 +14,20 @@ while getopts "PSe:M:A:" opt; do
   case $opt in
     P )
       CMS_API="https://joplin.herokuapp.com/api/graphql"
-      CMS_MEDIA="https://joplin-austin-gov-static.s3.amazonaws.com/production/media"
+      CMS_MEDIA="https://joplin3-austin-gov-static.s3.amazonaws.com/production/media"
       ;;
     S)
       CMS_API="https://joplin-staging.herokuapp.com/api/graphql"
-      CMS_MEDIA="https://joplin-austin-gov-static.s3.amazonaws.com/staging/media"
+      CMS_MEDIA="https://joplin3-austin-gov-static.s3.amazonaws.com/staging/media"
       ;;
     e )
       EXEC=$OPTARG
       ;;
     M )
       if [ "$OPTARG" == "prod" ]; then
-        CMS_MEDIA="https://joplin-austin-gov-static.s3.amazonaws.com/production/media"
+        CMS_MEDIA="https://joplin3-austin-gov-static.s3.amazonaws.com/production/media"
       elif [ "$OPTARG" == "staging" ]; then
-        CMS_MEDIA="https://joplin-austin-gov-static.s3.amazonaws.com/staging/media"
+        CMS_MEDIA="https://joplin3-austin-gov-static.s3.amazonaws.com/staging/media"
       else
         CMS_MEDIA=$OPTARG
       fi

--- a/static.config.js
+++ b/static.config.js
@@ -300,7 +300,7 @@ const checkUrl = async url => {
 
 const getWorkingDocumentLink = async filename => {
   // is this still needed? with brians new work?
-  /* 
+  /*
     depending on environment, returns a valid url from either staging or production
     used in getOfficialDocumentPageData
   */
@@ -316,8 +316,8 @@ const getWorkingDocumentLink = async filename => {
   // as well as any new docs we added when testing on staging
   if (process.env.CMS_DOCS === 'multiple') {
     const docUrls = [
-      'https://joplin-austin-gov-static.s3.amazonaws.com/production/media/documents',
-      'https://joplin-austin-gov-static.s3.amazonaws.com/staging/media/documents',
+      'https://joplin3-austin-gov-static.s3.amazonaws.com/production/media/documents',
+      'https://joplin3-austin-gov-static.s3.amazonaws.com/staging/media/documents',
     ];
 
     for (const url of docUrls) {
@@ -426,7 +426,7 @@ const buildPageAtUrl = async (
   client,
   pagesOfGuides,
 ) => {
-  /* 
+  /*
   buildPageAtUrl takes a page information object and the language client
   returns object with page url, template and data from appropriate query
   */
@@ -648,7 +648,7 @@ const getPagesOfGuidesData = async client => {
 
 const makeAllPages = async (langCode, incrementalPageId) => {
   /*
-    makeAllPages returns react-static data object with homepage 
+    makeAllPages returns react-static data object with homepage
     and all built pages as children for '/en', '/es' and '/'
   */
   const path = `/${!!langCode ? langCode : ''}`;


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description
Issue: cityofaustin/techstack#4343

We need a new CMS_MEDIA bucket to support our v3 => Prod transition

Publisher has eliminated CMS_DOCS=multiple. It doesn't hurt to keep it here in static.config, it'll just never be used. We can clean it up later.

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
   <!--- Netlify Example: `https://janis-<PR>.netlify.com/` --->  

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
