### PR TITLE
remove env_vars on production

### DIFF
--- a/.circleci/scripts/buildPublisherV2.js
+++ b/.circleci/scripts/buildPublisherV2.js
@@ -31,7 +31,7 @@ switch(branch) {
 
     payload = {
       "janis_branch": "production",
-      "env_vars": {REACT_STATIC_PREFETCH_RATE: 0},
+      "env_vars": {},
       "joplin_appname": "joplin",
       "build_type": "rebuild",
     }


### PR DESCRIPTION
Received error from Publisher via CircleCI:
`'value 0 in env_vars must be a string.'`

I could have stringified '0', but instead I opted to just remove env_vars from production pushes, since REACT_STATIC_PREFETCH_RATE='0' has no effect anyway.