### PR TITLE
Issue 4450: make entirety of external link buttons clickable

### DIFF
--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -39,6 +39,9 @@ const branchOverrides = {
   '4422-20-to-10': {
     joplin_appname: 'joplin',
   },
+  '4450-button': {
+    joplin_appname: 'joplin-staging',
+  },
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -81,8 +81,8 @@
   },
   "scripts": {
     "start-local": "./scripts/serve-local.sh",
-    "start-joplin-prod": "NODE_PATH=./src CMS_API='http://joplin.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin3-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='https://joplin3-austin-gov-static.s3.amazonaws.com/production/media/documents' npm-run-all -p watch-css start-js",
-    "start-joplin-staging": "NODE_PATH=./src CMS_API='http://joplin-staging.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin3-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='multiple' npm-run-all -p watch-css start-js",
+    "start-joplin-prod": "NODE_PATH=./src CMS_API='https://joplin.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin3-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='https://joplin3-austin-gov-static.s3.amazonaws.com/production/media/documents' npm-run-all -p watch-css start-js",
+    "start-joplin-staging": "NODE_PATH=./src CMS_API='https://joplin-staging.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin3-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='multiple' npm-run-all -p watch-css start-js",
     "start-joplin-pr": "NODE_PATH=./src CMS_API='https://joplin-pr-4355-media-releases.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin3-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='multiple' npm-run-all -p watch-css start-js",
     "start-joplin-local": "NODE_PATH=./src CMS_API='http://127.0.0.1:8000/api/graphql' CMS_MEDIA='http://127.0.0.1:8000/media' CMS_DOCS='multiple' npm-run-all -p watch-css start-js",
     "start-staging": "./scripts/serve-local.sh -S",

--- a/src/components/HtmlFromRichText/index.js
+++ b/src/components/HtmlFromRichText/index.js
@@ -49,21 +49,22 @@ const HtmlFromRichText = ({ content }) => {
         }
 
         // If we're getting the button div from drafttail, we need to turn it into
-        // an 'a' tag to make the whole thing a link
+        // an 'a' tag to make the whole thing a link.
+        // We set the placeholder 'rich-text-button-link' class within Joplin's register_rich_text_features hook.
         if (
           domNode.attribs.class &&
           domNode.attribs.class.includes('rich-text-button-link')
         ) {
-          const child = domNode.children && domNode.children[0];
-          if (child && child.name === 'a') {
+          const linkChild = domNode.children && domNode.children.find(c => c.name === "a");
+          if (linkChild) {
             // make it a link not a div
             domNode.name = 'a';
 
             // get the href from the wrapped link
-            domNode.attribs.href = child.attribs.href;
+            domNode.attribs.href = linkChild.attribs.href;
 
             // get child text element from the wrapped link
-            domNode.children = child.children;
+            domNode.children = linkChild.children;
           }
         }
       }


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description
https://github.com/cityofaustin/techstack/issues/4450
Bonus: https://github.com/cityofaustin/techstack/issues/4401

Alright, so I think @briaguya fixed this already. However, at some point something in our draftail parser changed.

```
<div class="usa-button-primary rich-text-button-link">
  <br>
  <a href="https://forms.austin.gov/police-complain/what-happened">Start</a>
</div>
```

Yeah there's a random `</br>` inserted now. So Brian's prior fix broke. I changed his logic to give us the desired output. Now the entire Button is clickable on desktop and mobile. This would be another great regression to test with some kind of cypress tool thing. I put it on a new wishlist https://github.com/cityofaustin/techstack/issues/4456

Also, I think I fixed the `start-joplin-staging` issue. The CMS_API var didn't have an https, and that's required now. Ya'll can test and see. If there's a different problem, then that issue can stay open. 

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
Clicking on any part of the "Start" button under the "online" option should take you to the OPO form.
https://janis-v3-4450-button.netlify.app/en/police-oversight/file-a-complaint-about-an-austin-police-officer/

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
