### PR TITLE
🚨Broken Official Document Links

### DIFF
--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -33,7 +33,7 @@ const branchOverrides = {
   '4289-page-guide': {
     joplin_appname: 'joplin-pr-v3',
   },
-  'es-no-results': {
+  'broken-link': {
     joplin_appname: 'joplin'
   },
   '4422-20-to-10': {

--- a/src/components/Pages/Search/searchResult.js
+++ b/src/components/Pages/Search/searchResult.js
@@ -10,7 +10,7 @@ const SearchResult = ({ page }) => {
     return <EventPageResult page={page}/>
   } else if ( page.pageType === "location page" ) {
     return <LocationPageResult page={page}/>
-  } else if ( page.pageType === "official document") {
+  } else if ( page.pageType === "document page") {
     return <OfficialDocumentPageDocumentResult page={page}/>
   } else {
     return <DefaultPageResult page={page}/>


### PR DESCRIPTION
Deployed: https://janis-v3-broken-links.netlify.com/

I Think in the most recent Addition the name of the pageType for `document page` was changed but not updated on the search result comonent. So, it was getting treated like a `default` result page. 

...Which used the incorrect URL structure. 