### PR TITLE
fixed inline-issue

### DIFF
--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -33,7 +33,7 @@ const branchOverrides = {
   '4289-page-guide': {
     joplin_appname: 'joplin-pr-v3',
   },
-  'mega-nav': { // Ok to remove
+  'right-div-fix': { // Ok to remove
     joplin_appname: 'joplin'
   },
   '4611-gzip': {

--- a/src/components/PageSections/Menu/_FullSiteMenu.scss
+++ b/src/components/PageSections/Menu/_FullSiteMenu.scss
@@ -261,11 +261,18 @@
 
 .coa-ThemesNav__right-controls {
   padding-right: 1rem;
+  display: inline;
+  div {
+    display: inline-block;
+  }
   a {
     font-size: $coa-font-size-xsmall;
   }
   a:first-child {
     padding-right: $coa-space-level3;
+  }
+  i {
+    display: inline;
   }
   @include mobile {
     display: none;


### PR DESCRIPTION
So, i just caught an oversight on my part on staging. The fix for tablet view still needed to handle inline for desktop view.... Here's that late night fix...
- Deployed: https://janis-v3-right-div-fix.netlify.com/

# What happened?
See... it's `display: block` but default now, which forced both external links down. This is from staging ATM. 
<img width="1267" alt="Screen Shot 2020-08-17 at 7 40 40 PM" src="https://user-images.githubusercontent.com/15821138/90459091-da11cc00-e0c5-11ea-9abf-6fe07d715230.png">


- - - - - - - - - - - -  - - - - - - - - - - - -  - - - - - - - - - - - -  - - - - - - - - - - - 


So, adding the styles fixed it for desktop. Also, here's a screenshot of it still working on tablet too.
![IMG_0009](https://user-images.githubusercontent.com/15821138/90459125-f4e44080-e0c5-11ea-8002-1731ac914a63.PNG)

# How can this be tested?
See: https://janis-v3-right-div-fix.netlify.com/
  - `311` & `Airport`, Should now be side-by-side

