### PR TITLE
4872 - janis side of adding ability to link in document summaries

### DIFF
--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -30,14 +30,8 @@ const branchOverrides = {
   '4289-page-guide': {
     joplin_appname: 'joplin-pr-v3',
   },
-  'right-div-fix': { // Ok to remove
-    joplin_appname: 'joplin'
-  },
   '4611-gzip': {
     joplin_appname: 'joplin'
-  },
-  '4591-janis-docs': {
-    joplin_appname: 'joplin-pr-4591-janis-docs',
   },
   '4872-link-doc-summary': {
     joplin_appname: 'joplin-pr-4872-link-summary',

--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -39,8 +39,8 @@ const branchOverrides = {
   '4591-janis-docs': {
     joplin_appname: 'joplin-pr-4591-janis-docs',
   },
-  '4758-hyperlink': {
-    joplin_appname: 'joplin-pr-4758-hyperlink',
+  '4872-link-doc-summary': {
+    joplin_appname: 'joplin-pr-4872-link-summary',
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "start-local": "./scripts/serve-local.sh",
     "start-joplin-prod": "NODE_PATH=./src CMS_API='https://joplin.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin3-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='https://joplin3-austin-gov-static.s3.amazonaws.com/production/media/documents' npm-run-all -p watch-css start-js",
     "start-joplin-staging": "NODE_PATH=./src CMS_API='https://joplin-staging.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin3-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='multiple' npm-run-all -p watch-css start-js",
-    "start-joplin-pr": "NODE_PATH=./src CMS_API='https://joplin-pr-4404-news-api-only.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin3-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='multiple' npm-run-all -p watch-css start-js",
+    "start-joplin-pr": "NODE_PATH=./src CMS_API='https://joplin-pr-4872-link-summary.herokuapp.com/api/graphql' CMS_MEDIA='https://joplin3-austin-gov-static.s3.amazonaws.com/staging/media' CMS_DOCS='multiple' npm-run-all -p watch-css start-js",
     "start-joplin-local": "NODE_PATH=./src CMS_API='http://127.0.0.1:8000/api/graphql' CMS_MEDIA='http://127.0.0.1:8000/media' CMS_DOCS='multiple' npm-run-all -p watch-css start-js",
     "start-staging": "./scripts/serve-local.sh -S",
     "start-prod": "./scripts/serve-local.sh -P",

--- a/src/components/Pages/OfficialDocuments/OfficialDocumentEntry.js
+++ b/src/components/Pages/OfficialDocuments/OfficialDocumentEntry.js
@@ -4,6 +4,7 @@ import { injectIntl } from 'react-intl';
 import moment from 'moment-timezone';
 
 import { officialdocuments as i18n } from 'js/i18n/definitions';
+import HtmlFromRichText from 'components/HtmlFromRichText';
 
 const OfficialDocumentEntry = ({ 
   page: {
@@ -20,6 +21,8 @@ const OfficialDocumentEntry = ({
   },
   intl
 }) => {
+
+  const summaryBlock = <HtmlFromRichText content={summary} /> 
 
   // If the link is a PDF with a pdfSize, then include it.
   const pdfComponent = (!!pdfSize) ?
@@ -42,7 +45,7 @@ const OfficialDocumentEntry = ({
       <a href={entryUrl(departments, slug)}>
         <h2 className="coa-OfficialDocumentPage__title">{title}</h2>
       </a>
-      <p>{summary}</p>
+      <p>{summaryBlock}</p>
       <div className="coa-OfficialDocumentPage__small-heading-container">
         <span className="coa-OfficialDocumentPage__small-heading">{intl.formatMessage(i18n.author)}:</span> {authoringOffice}
       </div>

--- a/src/components/Pages/OfficialDocuments/OfficialDocumentPage.js
+++ b/src/components/Pages/OfficialDocuments/OfficialDocumentPage.js
@@ -85,7 +85,9 @@ const OfficialDocumentPage = ({ officialDocumentPage, intl }) => {
           <div className="coa-Page__main-content">
             <div className="wrapper container-fluid">
               <div className="row">
-                <p className="coa-OfficialDocumentPage__summary">{summaryBlock}</p>
+                <p className="coa-OfficialDocumentPage__summary">
+                  {summaryBlock}
+                </p>
                 <OfficialDocumentCollectionsList
                   officialDocumentCollection={officialDocumentCollection}
                   mobile={true}

--- a/src/components/Pages/OfficialDocuments/OfficialDocumentPage.js
+++ b/src/components/Pages/OfficialDocuments/OfficialDocumentPage.js
@@ -10,6 +10,7 @@ import ContextualNav from 'components/PageSections/ContextualNav';
 import RelatedToMobile from 'components/PageSections/ContextualNav/RelatedToMobile';
 import Tile from 'components/Tiles/Tile';
 import UserFeedback from 'components/UserFeedback';
+import HtmlFromRichText from 'components/HtmlFromRichText';
 
 const OfficialDocumentCollectionsList = ({
   officialDocumentCollection,
@@ -59,6 +60,8 @@ const OfficialDocumentPage = ({ officialDocumentPage, intl }) => {
     <span className="coa-OfficialDocumentPage__pdf-size">(PDF {pdfSize})</span>
   ) : null;
 
+  const summaryBlock = <HtmlFromRichText content={summary} /> 
+
   return (
     <div>
       <Head>
@@ -82,7 +85,7 @@ const OfficialDocumentPage = ({ officialDocumentPage, intl }) => {
           <div className="coa-Page__main-content">
             <div className="wrapper container-fluid">
               <div className="row">
-                <p className="coa-OfficialDocumentPage__summary">{summary}</p>
+                <p className="coa-OfficialDocumentPage__summary">{summaryBlock}</p>
                 <OfficialDocumentCollectionsList
                   officialDocumentCollection={officialDocumentCollection}
                   mobile={true}


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Content would like to link to pages within Joplin in the official document summary fields. This PR changes the summary to be contained in an HTMLFromRichText component. 

There is a Joplin PR: https://github.com/cityofaustin/joplin/pull/801
<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
   <!--- Netlify Example: `https://janis-v3-<PR>.netlify.com/` --->  
https://joplin-pr-4872-link-summary.herokuapp.com/admin/pages/649/edit/#tab-content
https://janis-v3-4872-link-doc-summary.netlify.app/police-oversight/office-of-police-oversight-official-reports/#page=1

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
