### PR TITLE
4704 Search bar clear

### DIFF
--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -33,7 +33,7 @@ const branchOverrides = {
   '4289-page-guide': {
     joplin_appname: 'joplin-pr-v3',
   },
-  'search-doc-styles': { // Ok to remove
+  'clear-search': { // Ok to remove
     joplin_appname: 'joplin'
   },
   '4611-gzip': {

--- a/src/components/PageSections/SearchBar/_SearchBar.scss
+++ b/src/components/PageSections/SearchBar/_SearchBar.scss
@@ -29,8 +29,10 @@
   margin-right: 7px;
   border-radius: $coa-border-radius-medium;
   pointer-events: none;
+  opacity: 0;
   &.open {
     pointer-events: all;
+    opacity: 1;
   }
   @media screen and (max-width: 1135px) {
     width: 300px;

--- a/src/components/PageSections/SearchBar/index.js
+++ b/src/components/PageSections/SearchBar/index.js
@@ -12,7 +12,7 @@ const SearchBar = ({ intl }) => {
     if (isOpen) {
       if (typeof window !== 'undefined') {
         /*
-          If the search bar changed to do quick search results. Let's componentize the 
+          If the search bar changed to do quick search results. Let's componentize the
           quick search filter and use it here as well as on the search page.
         */
         const searchTerm = document.getElementById("coa_SearchBar__input")

--- a/src/components/Pages/Search/_SearchResult.scss
+++ b/src/components/Pages/Search/_SearchResult.scss
@@ -37,7 +37,7 @@
   }
 }
 
-.coa-search_result-topics.from {
+.coa-search_result-topics.from { 
   margin-top: $coa-space-level1;
 }
 

--- a/src/components/Pages/Search/_SearchResult.scss
+++ b/src/components/Pages/Search/_SearchResult.scss
@@ -37,7 +37,7 @@
   }
 }
 
-.coa-search_result-topics.from { 
+.coa-search_result-topics.from {
   margin-top: $coa-space-level1;
 }
 


### PR DESCRIPTION
Zenhub issue: https://app.zenhub.com/workspaces/techstack-5a78b88e1ce69f3510b678ef/issues/cityofaustin/techstack/4704 

Deployed: https://janis-v3-clear-search.netlify.com/

# Description

So, there was this odd effect where searching a term in the search bar wouldn't clear the actuall text out of the input, even when the bar is collapsed. This fixes that. See issue for more details on bug. 

# Checklist:
- [x] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
