### PR TITLE
4893 Update homepage banner image

### DIFF
--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -33,6 +33,9 @@ const branchOverrides = {
   '4611-gzip': {
     joplin_appname: 'joplin'
   },
+  'banner-image': {
+    joplin_appname: 'joplin'
+  },
   '4872-link-doc-summary': {
     joplin_appname: 'joplin-pr-4872-link-summary',
   }

--- a/static.config.js
+++ b/static.config.js
@@ -855,7 +855,7 @@ const makeAllPages = async (langCode, incrementalPageId) => {
       return {
         topServices,
         image: {
-          file: 'tomek-baginski-593896-unsplash',
+          file: 'banner_image', // Previous image for reference: tomek-baginski-593896-unsplash
           title: 'Lady Bird Lake',
         },
         events: allActiveEvents.events,


### PR DESCRIPTION
Zenhub issue: https://app.zenhub.com/workspaces/techstack-5a78b88e1ce69f3510b678ef/issues/cityofaustin/techstack/4893 

Deployed: https://janis-v3-banner-image.netlify.com/

# Description

Updated the new images on Joplin prod and hard-coded the new filename here. 

