### PR TITLE
fix view all events link

### DIFF
--- a/src/components/PageSections/EventsHomePage/index.js
+++ b/src/components/PageSections/EventsHomePage/index.js
@@ -23,7 +23,7 @@ const EventsHomePage = ({ events }) => {
         </div>
 
         <a
-          to={`/${intl.locale}/events`}
+          href={`/${intl.locale}/events`}
           className="coa-EventsHomePage__allEventsButton"
         >
           <div className="coa-EventsHomePage__allEventsButton--inner">


### PR DESCRIPTION
Issue: cityofaustin/techstack#5023

# Description

Change "to" to "href" fixes the view all events link on the homepage.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
   <!--- Netlify Example: `https://janis-v3-<PR>.netlify.com/` --->  

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
