### PR TITLE
Issue 5032: content manageable top services on homepage

### DIFF
--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -42,6 +42,9 @@ const branchOverrides = {
   '4776-elastic': {
     joplin_appname: 'joplin-pr-4776-elastic'
   },
+  '5032-top-pages': {
+    joplin_appname: 'joplin-pr-5032-top-pages'
+  }
 };
 
 module.exports = {

--- a/src/js/queries/getHomePagesQuery.js
+++ b/src/js/queries/getHomePagesQuery.js
@@ -1,0 +1,28 @@
+const getHomePagesQuery = `
+  query {
+    allHomePages {
+      edges {
+        node {
+          topPages {
+            edges {
+              node {
+                id
+                title
+                slug
+                live
+                coaGlobal
+                departments {
+                  id
+                  title
+                  slug
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
+export default getHomePagesQuery

--- a/static.config.js
+++ b/static.config.js
@@ -864,7 +864,7 @@ const makeAllPages = async (langCode, incrementalPageId) => {
         topPages = allServicePages
       }
 
-      let services = cleanLinks(allServicePages, 'service');
+      let services = cleanLinks(topPages, 'service');
 
       // Make sure we don't have any dupes in top services
       services = services.filter(

--- a/static.config.js
+++ b/static.config.js
@@ -20,6 +20,7 @@ import getDepartmentsPageQuery from 'js/queries/getDepartmentsPageQuery';
 import getAllGuidePagesSectionsQuery from 'js/queries/getAllGuidePagesSectionsQuery';
 import getEventPageQuery from 'js/queries/getEventPageQuery';
 import getNewsListPageQuery from 'js/queries/getNewsListPageQuery';
+import getHomePagesQuery from 'js/queries/getHomePagesQuery';
 
 import {
   cleanNavigation,
@@ -854,7 +855,14 @@ const makeAllPages = async (langCode, incrementalPageId) => {
     template: 'src/components/Pages/Home',
     children: allPages,
     getData: async () => {
-      const { allServicePages } = await client.request(topServicesQuery);
+      const { allHomePages } = await client.request(getHomePagesQuery);
+      let topPages = allHomePages.edges[0].node.topPages
+
+      // If no topPages were set, then default to using old method of getting the top 4 service pages
+      if (!topPages.edges.length) {
+        const { allServicePages } = await client.request(topServicesQuery);
+        topPages = allServicePages
+      }
 
       let services = cleanLinks(allServicePages, 'service');
 


### PR DESCRIPTION
https://github.com/cityofaustin/techstack/issues/5032
Joplin PR: https://github.com/cityofaustin/joplin/pull/824

# Description

This will render top services that are set by the HomePage in Joplin.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
   <!--- Netlify Example: `https://janis-v3-<PR>.netlify.com/` --->  

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
