### PR TITLE
5061 event list fix build

### DIFF
--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -32,8 +32,8 @@ const branchOverrides = {
   '3690-incremental': {
     joplin_appname: 'joplin-pr-3690-incremental',
   },
-  '4787-pdf-content': {
-    joplin_appname: 'joplin-pr-4787-pdf-docs',
+  '5061-event-list': {
+    joplin_appname: 'joplin',
   },
   '4776-elastic': {
     joplin_appname: 'joplin-pr-4776-elastic'

--- a/src/components/Pages/EventList/EventListEntry.js
+++ b/src/components/Pages/EventList/EventListEntry.js
@@ -121,7 +121,12 @@ const EventListEntry = ({
   relatedPage,
   relatedLocation,
   isSearchResult,
+  page
 }) => {
+  // EventListEntry is used in the EventList, Homepage, Location Related Events and Search Results.
+  // In the EventList it is used in PaginationStatic and the prop is called page. On every other instance
+  // it is event. This checks which prop to use.
+  event = event ? event : page;
   return (
     <a
       href={event.eventUrl}


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Pagination Static sends over the page component data in a prop called `page` which works for News List items but not for EventListEntrys. However everywhere else EventListEntry uses `event`. This adds a line to check what prop is being sent over. 
<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
   <!--- Netlify Example: `https://janis-v3-<PR>.netlify.com/` --->  

https://janis-v3-5061-event-list.netlify.app/

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
