### PR TITLE
4940 virtual event on Janis

### DIFF
--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -35,6 +35,9 @@ const branchOverrides = {
   '5012-contact-slash': {
     joplin_appname: 'joplin-pr-4940-virtual-event',
   },
+  '4940-virtual-event': {
+    joplin_appname: 'joplin-pr-4940-virtual-event',
+  },
 };
 
 module.exports = {

--- a/src/components/Pages/Event/EventDetailCard/EventDetailFees.js
+++ b/src/components/Pages/Event/EventDetailCard/EventDetailFees.js
@@ -25,6 +25,8 @@ const EventDetailFees = ({ eventIsFree, fees, registrationUrl, virtualLink }) =>
     </React.Fragment>
   );
 
+  console.log(virtualLinkFragment || registrationLinkFragment);
+
   return (
     <div className="coa-EventDetailItem">
       <i className="material-icons">local_play</i>

--- a/src/components/Pages/Event/EventDetailCard/EventDetailFees.js
+++ b/src/components/Pages/Event/EventDetailCard/EventDetailFees.js
@@ -15,18 +15,6 @@ const EventDetailFees = ({ eventIsFree, fees, registrationUrl, virtualLink }) =>
     </React.Fragment>
   );
 
-  const virtualLinkFragment = (
-    <React.Fragment>
-      {virtualLink ? (
-        <a href={virtualLink}>{intl.formatMessage(i18n.register)}</a> // todo : what does this say??
-      ) : (
-        null
-      )}
-    </React.Fragment>
-  );
-
-  console.log(virtualLinkFragment || registrationLinkFragment);
-
   return (
     <div className="coa-EventDetailItem">
       <i className="material-icons">local_play</i>
@@ -34,7 +22,7 @@ const EventDetailFees = ({ eventIsFree, fees, registrationUrl, virtualLink }) =>
         {eventIsFree ? (
           <div className="coa-EventDetailItem__fees-free">
             <div>{`${intl.formatMessage(i18n.free)}`}</div>
-            <div>{virtualLinkFragment || registrationLinkFragment}</div>
+            <div>{registrationLinkFragment}</div>
           </div>
         ) : (
           !!fees &&
@@ -49,7 +37,7 @@ const EventDetailFees = ({ eventIsFree, fees, registrationUrl, virtualLink }) =>
                     : `$${edge.node.fee}`}
                 </div>
               ))}
-              <div>{virtualLinkFragment || registrationLinkFragment}</div>
+              <div>{registrationLinkFragment}</div>
             </React.Fragment>
           )
         )}

--- a/src/components/Pages/Event/EventDetailCard/EventDetailFees.js
+++ b/src/components/Pages/Event/EventDetailCard/EventDetailFees.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useIntl } from 'react-intl';
 import { events as i18n } from 'js/i18n/definitions';
 
-const EventDetailFees = ({ eventIsFree, fees, registrationUrl }) => {
+const EventDetailFees = ({ eventIsFree, fees, registrationUrl, virtualLink }) => {
   const intl = useIntl();
 
   const registrationLinkFragment = (
@@ -15,6 +15,16 @@ const EventDetailFees = ({ eventIsFree, fees, registrationUrl }) => {
     </React.Fragment>
   );
 
+  const virtualLinkFragment = (
+    <React.Fragment>
+      {virtualLink ? (
+        <a href={virtualLink}>{intl.formatMessage(i18n.register)}</a> // todo : what does this say??
+      ) : (
+        null
+      )}
+    </React.Fragment>
+  );
+
   return (
     <div className="coa-EventDetailItem">
       <i className="material-icons">local_play</i>
@@ -22,7 +32,7 @@ const EventDetailFees = ({ eventIsFree, fees, registrationUrl }) => {
         {eventIsFree ? (
           <div className="coa-EventDetailItem__fees-free">
             <div>{`${intl.formatMessage(i18n.free)}`}</div>
-            <div>{registrationLinkFragment}</div>
+            <div>{virtualLinkFragment || registrationLinkFragment}</div>
           </div>
         ) : (
           !!fees &&
@@ -37,7 +47,7 @@ const EventDetailFees = ({ eventIsFree, fees, registrationUrl }) => {
                     : `$${edge.node.fee}`}
                 </div>
               ))}
-              <div>{registrationLinkFragment}</div>
+              <div>{virtualLinkFragment || registrationLinkFragment}</div>
             </React.Fragment>
           )
         )}

--- a/src/components/Pages/Event/EventDetailCard/EventDetailFees.js
+++ b/src/components/Pages/Event/EventDetailCard/EventDetailFees.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useIntl } from 'react-intl';
 import { events as i18n } from 'js/i18n/definitions';
 
-const EventDetailFees = ({ eventIsFree, fees, registrationUrl, virtualLink }) => {
+const EventDetailFees = ({ eventIsFree, fees, registrationUrl }) => {
   const intl = useIntl();
 
   const registrationLinkFragment = (

--- a/src/components/Pages/Event/EventDetailCard/index.js
+++ b/src/components/Pages/Event/EventDetailCard/index.js
@@ -22,12 +22,17 @@ const EventTime = ({ startTime, endTime, noon }) => {
   return null;
 };
 
-const EventLocationVirtual = () => (
-  <div className="coa-EventDetailItem">
-    <i className="material-icons">devices</i> 
-    Virtual Event
-  </div>
-)
+const EventLocationVirtual = () => {
+  const intl = useIntl();
+  return (
+    <div className="coa-EventDetailVirtual">
+      <i className="material-icons">devices</i> 
+      <div className="coa-EventDetailVirtual_content">
+        {intl.formatMessage(i18n.virtualEvent)}
+      </div>
+    </div>
+  )
+}
 
 const EventDetailCard = ({
   date,
@@ -45,8 +50,6 @@ const EventDetailCard = ({
   // make sure to capatalize the first letter in the date
   momentDate = momentDate.charAt(0).toUpperCase() + momentDate.slice(1);
   const noon = intl.formatMessage(i18n.noon);
-
-  console.log(location);
 
   return (
     <div className="coa-EventPage__EventDetailCard">

--- a/src/components/Pages/Event/EventDetailCard/index.js
+++ b/src/components/Pages/Event/EventDetailCard/index.js
@@ -24,7 +24,6 @@ const EventTime = ({ startTime, endTime, noon }) => {
 
 const EventLocationVirtual = ({eventLink, additionalInformation}) => {
   const intl = useIntl();
-  console.log(additionalInformation)
   return (
     <div className="coa-EventDetailVirtual">
       <i className="material-icons">devices</i> 
@@ -60,8 +59,6 @@ const EventDetailCard = ({
   // make sure to capatalize the first letter in the date
   momentDate = momentDate.charAt(0).toUpperCase() + momentDate.slice(1);
   const noon = intl.formatMessage(i18n.noon);
-
-  console.log(location)
 
   return (
     <div className="coa-EventPage__EventDetailCard">

--- a/src/components/Pages/Event/EventDetailCard/index.js
+++ b/src/components/Pages/Event/EventDetailCard/index.js
@@ -22,13 +22,19 @@ const EventTime = ({ startTime, endTime, noon }) => {
   return null;
 };
 
-const EventLocationVirtual = () => {
+const EventLocationVirtual = ({eventLink, eventCode}) => {
   const intl = useIntl();
   return (
     <div className="coa-EventDetailVirtual">
       <i className="material-icons">devices</i> 
       <div className="coa-EventDetailVirtual_content">
         {intl.formatMessage(i18n.virtualEvent)}
+        <p>
+          <a href={eventLink}>
+            {eventLink}
+          </a>
+        </p>
+        {!!eventCode && <p>{eventCode}</p>}
       </div>
     </div>
   )
@@ -50,8 +56,6 @@ const EventDetailCard = ({
   // make sure to capatalize the first letter in the date
   momentDate = momentDate.charAt(0).toUpperCase() + momentDate.slice(1);
   const noon = intl.formatMessage(i18n.noon);
-
-  // todo: we are going to have to be able to handle two locations, virtual and physical. or just one
 
   return (
     <div className="coa-EventPage__EventDetailCard">
@@ -84,7 +88,10 @@ const EventDetailCard = ({
         />
       ) : null}
       {location && (location.locationType === 'virtual_event' || location.virtualEvent) ? 
-        <EventLocationVirtual />
+        <EventLocationVirtual 
+          eventLink = {location.virtualEvent.eventLink}
+          eventCode = {location.virtualEvent.additionalDetails}
+        />
         : null}
       <EventDetailFees
         eventIsFree={eventIsFree}

--- a/src/components/Pages/Event/EventDetailCard/index.js
+++ b/src/components/Pages/Event/EventDetailCard/index.js
@@ -22,6 +22,13 @@ const EventTime = ({ startTime, endTime, noon }) => {
   return null;
 };
 
+const EventLocationVirtual = () => (
+  <div className="coa-EventDetailItem">
+    <i className="material-icons">devices</i> 
+    Virtual Event
+  </div>
+)
+
 const EventDetailCard = ({
   date,
   startTime,
@@ -39,6 +46,8 @@ const EventDetailCard = ({
   momentDate = momentDate.charAt(0).toUpperCase() + momentDate.slice(1);
   const noon = intl.formatMessage(i18n.noon);
 
+  console.log(location);
+
   return (
     <div className="coa-EventPage__EventDetailCard">
       <div className="coa-EventDetailItem">
@@ -48,17 +57,17 @@ const EventDetailCard = ({
           <EventTime startTime={startTime} endTime={endTime} noon={noon} />
         </div>
       </div>
-      {location && location.locationType === 'city_location' ? (
+      {location && location.locationType === 'city_of_Austin_location' ? (
         <EventLocationDetail
-          name={location.cityLocation.title}
-          street={location.cityLocation.physicalStreet}
-          city={location.cityLocation.physicalCity}
-          state={location.cityLocation.physicalState}
-          zip={location.cityLocation.physicalZip}
-          unit={location.cityLocation.physicalUnit}
+          name={location.cityOfAustinLocation.title}
+          street={location.cityOfAustinLocation.physicalStreet}
+          city={location.cityOfAustinLocation.physicalCity}
+          state={location.cityOfAustinLocation.physicalState}
+          zip={location.cityOfAustinLocation.physicalZip}
+          unit={location.cityOfAustinLocation.physicalUnit}
           additionalDetails={location.additionalDetails}
         />
-      ) : location && location.locationType === 'remote_location' ? (
+      ) : location && location.locationType === 'remote_non_Coa_location' ? (
         <EventLocationDetail
           name={location.remoteLocation.name}
           street={location.remoteLocation.street}
@@ -69,14 +78,17 @@ const EventDetailCard = ({
           additionalDetails={location.additionalDetails}
         />
       ) : null}
+      {location && location.locationType === 'virtual_event' ? 
+        <EventLocationVirtual />
+        : null}
       <EventDetailFees
         eventIsFree={eventIsFree}
         fees={fees}
         registrationUrl={registrationUrl}
       />
-      {location && location.locationType === 'city_location' ? (
+      {location && location.locationType === 'city_of_Austin_location' ? (
         <a
-          href={`/${intl.locale}/location/${location.cityLocation.slug}/`}
+          href={`/${intl.locale}/location/${location.cityOfAustinLocation.slug}/`}
           className="coa-EventDetailItem__location-link"
         >
           <div className="coa-EventDetailItem__location-link-text">

--- a/src/components/Pages/Event/EventDetailCard/index.js
+++ b/src/components/Pages/Event/EventDetailCard/index.js
@@ -37,7 +37,7 @@ const EventLocationVirtual = ({eventLink, additionalInformation}) => {
         </div>
         {!!additionalInformation &&
           <div className="coa-EventDetailVirtual__content-code">
-            {`Meeting Code: ${additionalInformation}`}
+            {`${intl.formatMessage(i18n.meetingCode)}: ${additionalInformation}`}
           </div>}
       </div>
     </div>

--- a/src/components/Pages/Event/EventDetailCard/index.js
+++ b/src/components/Pages/Event/EventDetailCard/index.js
@@ -51,6 +51,8 @@ const EventDetailCard = ({
   momentDate = momentDate.charAt(0).toUpperCase() + momentDate.slice(1);
   const noon = intl.formatMessage(i18n.noon);
 
+  // todo: we are going to have to be able to handle two locations, virtual and physical. or just one
+
   return (
     <div className="coa-EventPage__EventDetailCard">
       <div className="coa-EventDetailItem">
@@ -81,13 +83,14 @@ const EventDetailCard = ({
           additionalDetails={location.additionalDetails}
         />
       ) : null}
-      {location && location.locationType === 'virtual_event' ? 
+      {location && (location.locationType === 'virtual_event' || location.virtualEvent) ? 
         <EventLocationVirtual />
         : null}
       <EventDetailFees
         eventIsFree={eventIsFree}
         fees={fees}
         registrationUrl={registrationUrl}
+        virtualLink={location.virtualEvent && location.virtualEvent.eventLink}
       />
       {location && location.locationType === 'city_of_Austin_location' ? (
         <a

--- a/src/components/Pages/Event/EventDetailCard/index.js
+++ b/src/components/Pages/Event/EventDetailCard/index.js
@@ -22,8 +22,9 @@ const EventTime = ({ startTime, endTime, noon }) => {
   return null;
 };
 
-const EventLocationVirtual = ({eventLink, eventCode}) => {
+const EventLocationVirtual = ({eventLink, additionalInformation}) => {
   const intl = useIntl();
+  console.log(additionalInformation)
   return (
     <div className="coa-EventDetailVirtual">
       <i className="material-icons">devices</i> 
@@ -34,7 +35,7 @@ const EventLocationVirtual = ({eventLink, eventCode}) => {
             {eventLink}
           </a>
         </p>
-        {!!eventCode && <p>{eventCode}</p>}
+        {!!additionalInformation && <p>{`Meeting Code:${additionalInformation}`}</p>}
       </div>
     </div>
   )
@@ -56,6 +57,8 @@ const EventDetailCard = ({
   // make sure to capatalize the first letter in the date
   momentDate = momentDate.charAt(0).toUpperCase() + momentDate.slice(1);
   const noon = intl.formatMessage(i18n.noon);
+
+  console.log(location)
 
   return (
     <div className="coa-EventPage__EventDetailCard">
@@ -90,7 +93,7 @@ const EventDetailCard = ({
       {location && (location.locationType === 'virtual_event' || location.virtualEvent) ? 
         <EventLocationVirtual 
           eventLink = {location.virtualEvent.eventLink}
-          eventCode = {location.virtualEvent.additionalDetails}
+          additionalInformation = {location.virtualEvent.additionalInformation}
         />
         : null}
       <EventDetailFees

--- a/src/components/Pages/Event/EventDetailCard/index.js
+++ b/src/components/Pages/Event/EventDetailCard/index.js
@@ -28,14 +28,17 @@ const EventLocationVirtual = ({eventLink, additionalInformation}) => {
   return (
     <div className="coa-EventDetailVirtual">
       <i className="material-icons">devices</i> 
-      <div className="coa-EventDetailVirtual_content">
+      <div className="coa-EventDetailVirtual__content">
         {intl.formatMessage(i18n.virtualEvent)}
-        <p>
+        <div>
           <a href={eventLink}>
             {eventLink}
           </a>
-        </p>
-        {!!additionalInformation && <p>{`Meeting Code:${additionalInformation}`}</p>}
+        </div>
+        {!!additionalInformation &&
+          <div className="coa-EventDetailVirtual__content-code">
+            {`Meeting Code: ${additionalInformation}`}
+          </div>}
       </div>
     </div>
   )

--- a/src/components/Pages/Event/_Event.scss
+++ b/src/components/Pages/Event/_Event.scss
@@ -111,10 +111,15 @@
 
 }
 
-.coa-EventDetailVirtual_content {
+.coa-EventDetailVirtual__content {
   margin-left: 1.2rem;
   font-size: 1.4rem;
-  line-height: 2.2rem;}
+  line-height: 2.2rem;
+}
+
+.coa-EventDetailVirtual__content-code {
+  color: #5c5c5c;
+}
 
 .coa-EventsPage__contacts-desktop {
   width: 350px;

--- a/src/components/Pages/Event/_Event.scss
+++ b/src/components/Pages/Event/_Event.scss
@@ -103,6 +103,19 @@
   padding-top: 0.25rem;
 }
 
+.coa-EventDetailVirtual {
+  display: flex;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+  padding-bottom: 2rem;
+
+}
+
+.coa-EventDetailVirtual_content {
+  margin-left: 1.2rem;
+  font-size: 1.4rem;
+  line-height: 2.2rem;}
+
 .coa-EventsPage__contacts-desktop {
   width: 350px;
   margin-top: 2rem;

--- a/src/components/Pages/Event/index.js
+++ b/src/components/Pages/Event/index.js
@@ -10,7 +10,7 @@ import UserFeedback from 'components/UserFeedback';
 import EventDetailCard from 'components/Pages/Event/EventDetailCard';
 
 import { events as i18n } from 'js/i18n/definitions';
-import { cleanLocations } from 'js/helpers/cleanData.js'
+import { cleanLocation } from 'js/helpers/cleanData.js'
 
 const EventDate = ({ date, canceled }) => {
   const intl = useIntl();
@@ -52,9 +52,7 @@ const EventPage = ({ eventPage }) => {
     },
   } = eventPage ? { eventPage } : useRouteData();
 
-  // until we have support for multiple locations, we're taking the first one
-  // const location = locations[0];
-  const location = cleanLocations(locations);
+  const location = cleanLocation(locations);
 
   return (
     <div>

--- a/src/components/Pages/Event/index.js
+++ b/src/components/Pages/Event/index.js
@@ -10,6 +10,7 @@ import UserFeedback from 'components/UserFeedback';
 import EventDetailCard from 'components/Pages/Event/EventDetailCard';
 
 import { events as i18n } from 'js/i18n/definitions';
+import cleanLocations from 'js/helpers/cleanData.js'
 
 const EventDate = ({ date, canceled }) => {
   const intl = useIntl();
@@ -52,7 +53,8 @@ const EventPage = ({ eventPage }) => {
   } = eventPage ? { eventPage } : useRouteData();
 
   // until we have support for multiple locations, we're taking the first one
-  const location = locations[0];
+  // const location = locations[0];
+  const location = cleanLocations(locations);
 
   return (
     <div>

--- a/src/components/Pages/Event/index.js
+++ b/src/components/Pages/Event/index.js
@@ -10,7 +10,7 @@ import UserFeedback from 'components/UserFeedback';
 import EventDetailCard from 'components/Pages/Event/EventDetailCard';
 
 import { events as i18n } from 'js/i18n/definitions';
-import cleanLocations from 'js/helpers/cleanData.js'
+import { cleanLocations } from 'js/helpers/cleanData.js'
 
 const EventDate = ({ date, canceled }) => {
   const intl = useIntl();

--- a/src/components/Pages/EventList/EventListEntry.js
+++ b/src/components/Pages/EventList/EventListEntry.js
@@ -71,12 +71,17 @@ const EventDateListDetails = ({
       ? `${formatTimeLang(startTime, noon)}–${formatTimeLang(endTime, noon)}`
       : formatTimeLang(startTime, noon);
 
+  console.log(location)
   let locationName = null;
   if (location) {
-    locationName =
-      location.locationType === 'city_location'
-        ? location.cityLocation.title
-        : location.remoteLocation.name;
+    if (location.locationType === 'virtual_event') {
+      locationName = 'Virtual event'; //todo: translate!
+    } else {
+      locationName =
+        location.locationType === 'city_of_Austin_location'
+          ? location.cityOfAustinLocation.title
+          : location.remoteNonCoaLocation.name;
+    }
   }
 
   // Joplin lets a user mark an event as free but also include costs.

--- a/src/components/Pages/EventList/EventListEntry.js
+++ b/src/components/Pages/EventList/EventListEntry.js
@@ -71,11 +71,10 @@ const EventDateListDetails = ({
       ? `${formatTimeLang(startTime, noon)}–${formatTimeLang(endTime, noon)}`
       : formatTimeLang(startTime, noon);
 
-  console.log(location)
   let locationName = null;
   if (location) {
     if (location.locationType === 'virtual_event') {
-      locationName = 'Virtual event'; //todo: translate!
+      locationName = intl.formatMessage(i18n.virtualEvent);
     } else {
       locationName =
         location.locationType === 'city_of_Austin_location'

--- a/src/js/helpers/cleanData.js
+++ b/src/js/helpers/cleanData.js
@@ -106,11 +106,11 @@ export const cleanLocation = locations => {
     if (locations[0].locationType === 'virtual_event') {
       location = {...locations[1]};
       location.virtualEvent = locations[0].virtualEvent;
-      location.virtualEvent.additionalDetails = locations[0].additionalDetails;
+      location.virtualEvent.additionalInformation = locations[0].virtualEvent.additionalInformation;
     } else {
       location = {...locations[0]};
       location.virtualEvent = locations[1].virtualEvent;
-      location.virtualEvent.additionalDetails = locations[1].additionalDetails;
+      location.virtualEvent.additionalInformation = locations[1].virtualEvent.additionalInformation;
     }
   }
   return location

--- a/src/js/helpers/cleanData.js
+++ b/src/js/helpers/cleanData.js
@@ -109,7 +109,7 @@ export const cleanLocation = locations => {
       location.virtualEvent.additionalDetails = locations[0].additionalDetails;
     } else {
       location = {...locations[0]};
-      location.virtualEvent = locations[1]].virtualEvent;
+      location.virtualEvent = locations[1].virtualEvent;
       location.virtualEvent.additionalDetails = locations[1].additionalDetails;
     }
   }

--- a/src/js/helpers/cleanData.js
+++ b/src/js/helpers/cleanData.js
@@ -94,6 +94,28 @@ export const cleanContact = contact => {
   return cleaned;
 };
 
+export const cleanLocation = locations => {
+  // with the introduction of virtual events, we no longer can just accept the 
+  // first location in the array, since events can have two locations (virtual 
+  // plus a physical one)
+  let location = {}
+  if (locations.length === 1) {
+    return locations[0]
+  }
+  if (locations.length === 2) {
+    if (locations[0].locationType === 'virtual_event') {
+      location = {...locations[1]};
+      location.virtualEvent = locations[0]].virtualEvent;
+      location.virtualEvent.additionalDetails = locations[0].additionalDetails;
+    } else {
+      location = {...locations[0]};
+      location.virtualEvent = locations[1]].virtualEvent;
+      location.virtualEvent.additionalDetails = locations[1].additionalDetails;
+    }
+  }
+  return location
+}
+
 export const cleanLocationPageUrl = janisUrls => {
   if (!!janisUrls.length) {
     return janisUrls[0];

--- a/src/js/helpers/cleanData.js
+++ b/src/js/helpers/cleanData.js
@@ -105,7 +105,7 @@ export const cleanLocation = locations => {
   if (locations.length === 2) {
     if (locations[0].locationType === 'virtual_event') {
       location = {...locations[1]};
-      location.virtualEvent = locations[0]].virtualEvent;
+      location.virtualEvent = locations[0].virtualEvent;
       location.virtualEvent.additionalDetails = locations[0].additionalDetails;
     } else {
       location = {...locations[0]};

--- a/src/js/i18n/definitions.js
+++ b/src/js/i18n/definitions.js
@@ -566,6 +566,7 @@ export const events = defineMessages({
   noon: 'Noon',
   upcoming: 'Upcoming events',
   viewAll: 'View all events',
+  virtualEvent: 'Virtual event'
 });
 
 export const alert = defineMessages({

--- a/src/js/i18n/definitions.js
+++ b/src/js/i18n/definitions.js
@@ -566,7 +566,8 @@ export const events = defineMessages({
   noon: 'Noon',
   upcoming: 'Upcoming events',
   viewAll: 'View all events',
-  virtualEvent: 'Virtual event'
+  virtualEvent: 'Virtual event',
+  meetingCode: 'Meeting code'
 });
 
 export const alert = defineMessages({

--- a/src/js/i18n/locales/es.json
+++ b/src/js/i18n/locales/es.json
@@ -173,6 +173,7 @@
   "events.upcoming": "Próximos eventos",
   "events.viewAll": "Ver todos los eventos",
   "events.virtualEvent": "Evento virtual",
+  "events.meetingCode": "Clave de acceso",
   "alert.getLatest": "Obtenga información actual sobre el coronavirus (COVID-19) en Austin",
   "search.search": "Buscar",
   "search.results": "Resultados para {searchedTerm}",

--- a/src/js/i18n/locales/es.json
+++ b/src/js/i18n/locales/es.json
@@ -172,6 +172,7 @@
   "events.noon": "Mediodía",
   "events.upcoming": "Próximos eventos",
   "events.viewAll": "Ver todos los eventos",
+  "events.virtualEvent": "Evento virtual",
   "alert.getLatest": "Obtenga información actual sobre el coronavirus (COVID-19) en Austin",
   "search.search": "Buscar",
   "search.results": "Resultados para {searchedTerm}",

--- a/src/js/queries/allPagesQuery.js
+++ b/src/js/queries/allPagesQuery.js
@@ -165,6 +165,7 @@ query allPagesQuery($after: String, $batchSize: Int) {
                 }
                 virtualEvent {
                   eventLink
+                  additionalInformation
                 }
               }
               eventIsFree,

--- a/src/js/queries/allPagesQuery.js
+++ b/src/js/queries/allPagesQuery.js
@@ -145,7 +145,7 @@ query allPagesQuery($after: String, $batchSize: Int) {
               locations {
                 additionalDetails
                 locationType
-                cityLocation {
+                cityOfAustinLocation {
                   id
                   title
                   physicalStreet
@@ -155,13 +155,16 @@ query allPagesQuery($after: String, $batchSize: Int) {
                   physicalUnit
                   slug
                 }
-                remoteLocation {
+                remoteNonCoaLocation {
                   name
                   street
                   city
                   state
                   zip
                   unit
+                }
+                virtualEvent {
+                  eventLink
                 }
               }
               eventIsFree,

--- a/src/js/queries/eventPageFragment.js
+++ b/src/js/queries/eventPageFragment.js
@@ -76,6 +76,7 @@ const eventPageFragment = `
       }
       virtualEvent {
         eventLink
+        additionalInformation
       } 
     }
     eventIsFree

--- a/src/js/queries/eventPageFragment.js
+++ b/src/js/queries/eventPageFragment.js
@@ -56,7 +56,7 @@ const eventPageFragment = `
     locations {
       additionalDetails
       locationType
-      cityLocation {
+      cityOfAustinLocation {
         id
         title
         physicalStreet
@@ -66,7 +66,7 @@ const eventPageFragment = `
         physicalUnit
         slug
       }
-      remoteLocation {
+      remoteNonCoaLocation {
         name
         street
         city
@@ -74,6 +74,9 @@ const eventPageFragment = `
         zip
         unit
       }
+      virtualEvent {
+        eventLink
+      } 
     }
     eventIsFree
     fees {

--- a/src/js/queries/informationPageFragment.js
+++ b/src/js/queries/informationPageFragment.js
@@ -31,7 +31,7 @@ const informationPageFragment = `
       locations {
         additionalDetails
         locationType
-        cityLocation {
+        cityOfAustinLocation {
           id
           title
           physicalStreet
@@ -41,13 +41,16 @@ const informationPageFragment = `
           physicalUnit
           slug
         }
-        remoteLocation {
+        remoteNonCoaLocation {
           name
           street
           city
           state
           zip
           unit
+        }
+        virtualEvent {
+          eventLink
         }
       }
       eventIsFree,

--- a/src/js/queries/informationPageFragment.js
+++ b/src/js/queries/informationPageFragment.js
@@ -51,6 +51,7 @@ const informationPageFragment = `
         }
         virtualEvent {
           eventLink
+          additionalInformation
         }
       }
       eventIsFree,

--- a/src/js/queries/locationPageFragment.js
+++ b/src/js/queries/locationPageFragment.js
@@ -118,7 +118,7 @@ const locationPageFragment = `
       locations {
         additionalDetails
         locationType
-        cityLocation {
+        cityOfAustinLocation {
           id
           title
           physicalStreet
@@ -128,13 +128,16 @@ const locationPageFragment = `
           physicalUnit
           slug
         }
-        remoteLocation {
+        remoteNonCoaLocation {
           name
           street
           city
           state
           zip
           unit
+        }
+        virtualEvent {
+          eventLink
         }
       }
       eventIsFree,

--- a/src/js/queries/locationPageFragment.js
+++ b/src/js/queries/locationPageFragment.js
@@ -138,6 +138,7 @@ const locationPageFragment = `
         }
         virtualEvent {
           eventLink
+          additionalInformation
         }
       }
       eventIsFree,

--- a/src/js/queries/servicePageFragment.js
+++ b/src/js/queries/servicePageFragment.js
@@ -47,6 +47,7 @@ const servicePageFragment = `
         }
         virtualEvent {
           eventLink
+          additionalInformation
         } 
       }
       eventIsFree,

--- a/src/js/queries/servicePageFragment.js
+++ b/src/js/queries/servicePageFragment.js
@@ -27,7 +27,7 @@ const servicePageFragment = `
       locations {
         additionalDetails
         locationType
-        cityLocation {
+        cityOfAustinLocation {
           id
           title
           physicalStreet
@@ -37,7 +37,7 @@ const servicePageFragment = `
           physicalUnit
           slug
         }
-        remoteLocation {
+        remoteNonCoaLocation {
           name
           street
           city
@@ -45,6 +45,9 @@ const servicePageFragment = `
           zip
           unit
         }
+        virtualEvent {
+          eventLink
+        } 
       }
       eventIsFree,
       registrationUrl,


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

The janis side of showing virtual events. 

This was not as straight forward as I initially thought since events now can be at "2" locations, virtual and physical. However it also can be at just at one location. The clean locations function in `CleanData` sorts those scenarios out. 


<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
https://janis-v3-4940-virtual-event.netlify.app/event/2020/11/13/virtual-event-with-physical/
   <!--- Netlify Example: `https://janis-v3-<PR>.netlify.com/` --->  

# Checklist:
- [x] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
