### PR TITLE
To test deployed url api requests

### DIFF
--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -39,7 +39,7 @@ const branchOverrides = {
   '4611-gzip': {
     joplin_appname: 'joplin',
   },
-  'out-link': {
+  'surface-api-test': {
     joplin_appname: 'joplin',
   },
   '5012-contact-slash': {

--- a/static.config.js
+++ b/static.config.js
@@ -343,6 +343,8 @@ const getOfficialDocumentCollectionData = async (page, instance, client, pageId)
 
   officialDocumentCollection.lowerBound = await getOfficialDocumentCollectionLowerBound(officialDocumentCollection.id, client);
 
+  console.log("officialDocumentCollection :", officialDocumentCollection)
+
   return { officialDocumentCollection: officialDocumentCollection };
 };
 


### PR DESCRIPTION
It's Dec. 1, 2020. If this date hasn't been updated in... idk... 20 days. It's ok to delete this PR. It was only intended to be a testing thingy anyway.