### PR TITLE
5081 chat bot on municourt pages

### DIFF
--- a/src/components/Alerts/index.js
+++ b/src/components/Alerts/index.js
@@ -8,8 +8,6 @@ const Alert = ({ badge, content, link, description }) => {
   const styleWithContent = content ? "textContent" : ""
   const intl = useIntl();
 
-  console.log(content, styleWithContent)
-
   return (
     <div>
     <div className={"coa-HomepageAlert__container "+styleWithContent}>

--- a/src/components/Pages/Department.js
+++ b/src/components/Pages/Department.js
@@ -5,17 +5,15 @@ import { injectIntl } from 'react-intl';
 import path from 'path';
 import Parser from 'html-react-parser';
 
-import { departmentPage as i18n } from 'js/i18n/definitions';
+import { departmentPage as i18n, misc as i18n2, services as i18n3 } from 'js/i18n/definitions';
 
 import SectionHeader from 'components/SectionHeader';
 import ContactDetails from 'components/Contact/ContactDetails';
 import PageBanner from 'components/PageBanner';
 import DirectorHeadshot from 'components/DirectorHeadshot';
 import PageHeader from 'components/PageHeader';
-
 import TileGroup from 'components/Tiles/TileGroup';
-
-import { misc as i18n2, services as i18n3 } from 'js/i18n/definitions';
+import TalkToComponent from 'components/TawkTo';
 
 const Department = ({ department, intl }) => {
   const {
@@ -74,6 +72,8 @@ const Department = ({ department, intl }) => {
     ) : !!relatedLinks.length ? (
       <RelatedContent />
     ) : null;
+
+  const isMuniCourt = title === 'Municipal Court' || title === 'Corte Municipal';
 
   return (
     <div>
@@ -162,6 +162,7 @@ const Department = ({ department, intl }) => {
           </div>
         </div>
       </div>
+      {isMuniCourt && <TalkToComponent />}
     </div>
   );
 };

--- a/src/components/Pages/Form.js
+++ b/src/components/Pages/Form.js
@@ -71,7 +71,6 @@ function FormContainer({
           offeredBy={contextualNavData.offeredBy}
         />
       )}
-      {isMuniCourt(contextualNavData) && <TalkToComponent />}
       <div id="coa-FormContainer__top">
         <PageHeader contentType={'information'} description={description}>
           {title}
@@ -108,6 +107,7 @@ function FormContainer({
           />
         )}
       </div>
+      {isMuniCourt(contextualNavData) && <TalkToComponent />}
     </div>
   );
 }

--- a/src/components/Pages/Form.js
+++ b/src/components/Pages/Form.js
@@ -10,6 +10,7 @@ import { injectIntl } from 'react-intl';
 import IframeResizer from 'iframe-resizer-react';
 import { misc as i18n2, services as i18n3 } from 'js/i18n/definitions';
 import { loader } from '../../js/animations/loader';
+import { isMuniCourt } from 'js/helpers/pageType.js'
 
 import PageHeader from 'components/PageHeader';
 import HtmlFromRichText from 'components/HtmlFromRichText';
@@ -19,6 +20,7 @@ import ContextualNav from 'components/PageSections/ContextualNav';
 import RelatedToMobile from '../PageSections/ContextualNav/RelatedToMobile';
 import RowContainer from 'components/ErrorMessages/RowContainer';
 import InfoISVG from 'components/SVGs/InfoI';
+import TalkToComponent from 'components/TawkTo';
 
 function FormContainer({
   formContainer: { title, description, formUrl, coaGlobal, contextualNavData },
@@ -69,6 +71,7 @@ function FormContainer({
           offeredBy={contextualNavData.offeredBy}
         />
       )}
+      {isMuniCourt(contextualNavData) && <TalkToComponent />}
       <div id="coa-FormContainer__top">
         <PageHeader contentType={'information'} description={description}>
           {title}

--- a/src/components/Pages/Information.js
+++ b/src/components/Pages/Information.js
@@ -4,6 +4,7 @@ import { injectIntl } from 'react-intl';
 import path from 'path';
 
 import { misc as i18n2, services as i18n3 } from 'js/i18n/definitions';
+import { isMuniCourt } from 'js/helpers/pageType.js'
 
 import PageBanner from 'components/PageBanner';
 import PageHeader from 'components/PageHeader';
@@ -17,6 +18,7 @@ import RelatedToMobile from '../PageSections/ContextualNav/RelatedToMobile';
 import PageIsPartOfContainer from 'components/PageSections/PageIsPartOfContainer';
 import RelatedEvents from 'components/PageSections/RelatedEvents';
 import UserFeedback from 'components/UserFeedback';
+import TalkToComponent from 'components/TawkTo';
 
 const InformationPage = ({ informationPage, intl }) => {
   const {
@@ -93,6 +95,7 @@ const InformationPage = ({ informationPage, intl }) => {
         )}
       </div>
       <UserFeedback />
+      {isMuniCourt(contextualNavData) && <TalkToComponent />}
     </div>
   );
 };

--- a/src/components/Pages/Service.js
+++ b/src/components/Pages/Service.js
@@ -4,6 +4,7 @@ import { injectIntl } from 'react-intl';
 import path from 'path';
 
 import { misc as i18n2, services as i18n3 } from 'js/i18n/definitions';
+import { isMuniCourt } from 'js/helpers/pageType.js'
 
 import PageBanner from 'components/PageBanner';
 import PageHeader from 'components/PageHeader';
@@ -39,9 +40,6 @@ const Service = ({ service, intl }) => {
     // not the biggest fan of this logic but
     // it gets previews working with hooks
   } = service ? { service } : useRouteData();
-
-  console.log('parent: ', contextualNavData.parent)
-  console.log('offered ', contextualNavData.offeredBy)
 
   return (
     <div>
@@ -124,7 +122,7 @@ const Service = ({ service, intl }) => {
         )}
       </div>
       <UserFeedback />
-      <TalkToComponent />
+      {isMuniCourt(contextualNavData) && <TalkToComponent />}
     </div>
   );
 };

--- a/src/components/Pages/Service.js
+++ b/src/components/Pages/Service.js
@@ -17,6 +17,7 @@ import RelatedToMobile from '../PageSections/ContextualNav/RelatedToMobile';
 import PageIsPartOfContainer from 'components/PageSections/PageIsPartOfContainer';
 import RelatedEvents from 'components/PageSections/RelatedEvents';
 import UserFeedback from 'components/UserFeedback';
+import TalkToComponent from 'components/TawkTo';
 
 const Service = ({ service, intl }) => {
   const {
@@ -38,6 +39,9 @@ const Service = ({ service, intl }) => {
     // not the biggest fan of this logic but
     // it gets previews working with hooks
   } = service ? { service } : useRouteData();
+
+  console.log('parent: ', contextualNavData.parent)
+  console.log('offered ', contextualNavData.offeredBy)
 
   return (
     <div>
@@ -120,6 +124,7 @@ const Service = ({ service, intl }) => {
         )}
       </div>
       <UserFeedback />
+      <TalkToComponent />
     </div>
   );
 };

--- a/src/components/TawkTo/index.js
+++ b/src/components/TawkTo/index.js
@@ -1,0 +1,37 @@
+import React, { useEffect } from 'react';
+
+// <!--Start of Tawk.to Script-->
+// <script type="text/javascript">
+// var Tawk_API=Tawk_API||{}, Tawk_LoadStart=new Date();
+// (function(){
+// var s1=document.createElement("script"),s0=document.getElementsByTagName("script")[0];
+// s1.async=true;
+// s1.src='https://embed.tawk.to/5d02b7f653d10a56bd79fa83/default';
+// s1.charset='UTF-8';
+// s1.setAttribute('crossorigin','*');
+// s0.parentNode.insertBefore(s1,s0);
+// })();
+// </script>
+// <!--End of Tawk.to Script-->
+
+const useScript = url => {
+  useEffect(() => {
+    const script = document.createElement('script');
+
+    script.src = url;
+    script.async = true;
+
+    document.body.appendChild(script);
+
+    return () => {
+      document.body.removeChild(script);
+    }
+  }, [url]);
+};
+
+const TalkToComponent = () => {
+  useScript("https://embed.tawk.to/5f401761cc6a6a5947adc27c/default")
+  return null
+}
+
+export default TalkToComponent;

--- a/src/components/TawkTo/index.js
+++ b/src/components/TawkTo/index.js
@@ -1,19 +1,5 @@
 import React, { useEffect } from 'react';
 
-// <!--Start of Tawk.to Script-->
-// <script type="text/javascript">
-// var Tawk_API=Tawk_API||{}, Tawk_LoadStart=new Date();
-// (function(){
-// var s1=document.createElement("script"),s0=document.getElementsByTagName("script")[0];
-// s1.async=true;
-// s1.src='https://embed.tawk.to/5d02b7f653d10a56bd79fa83/default';
-// s1.charset='UTF-8';
-// s1.setAttribute('crossorigin','*');
-// s0.parentNode.insertBefore(s1,s0);
-// })();
-// </script>
-// <!--End of Tawk.to Script-->
-
 const useScript = url => {
   useEffect(() => {
     const script = document.createElement('script');
@@ -30,7 +16,7 @@ const useScript = url => {
 };
 
 const TalkToComponent = () => {
-  useScript("https://embed.tawk.to/5f401761cc6a6a5947adc27c/default")
+  useScript("https://embed.tawk.to/5d02b7f653d10a56bd79fa83/default")
   return null
 }
 

--- a/src/components/TawkTo/index.js
+++ b/src/components/TawkTo/index.js
@@ -16,7 +16,8 @@ const useScript = url => {
 };
 
 const TalkToComponent = () => {
-  useScript("https://embed.tawk.to/5d02b7f653d10a56bd79fa83/default")
+  //useScript("https://embed.tawk.to/5f401761cc6a6a5947adc27c/default") // chia
+  useScript("https://embed.tawk.to/5d02b7f653d10a56bd79fa83/default") // municourt
   return null
 }
 

--- a/src/components/TawkTo/index.js
+++ b/src/components/TawkTo/index.js
@@ -16,8 +16,7 @@ const useScript = url => {
 };
 
 const TalkToComponent = () => {
-  useScript("https://embed.tawk.to/5f401761cc6a6a5947adc27c/default") // chia
-  //useScript("https://embed.tawk.to/5d02b7f653d10a56bd79fa83/default") // municourt
+  useScript("https://embed.tawk.to/5d02b7f653d10a56bd79fa83/default")
   return null
 }
 

--- a/src/components/TawkTo/index.js
+++ b/src/components/TawkTo/index.js
@@ -16,8 +16,8 @@ const useScript = url => {
 };
 
 const TalkToComponent = () => {
-  //useScript("https://embed.tawk.to/5f401761cc6a6a5947adc27c/default") // chia
-  useScript("https://embed.tawk.to/5d02b7f653d10a56bd79fa83/default") // municourt
+  useScript("https://embed.tawk.to/5f401761cc6a6a5947adc27c/default") // chia
+  //useScript("https://embed.tawk.to/5d02b7f653d10a56bd79fa83/default") // municourt
   return null
 }
 

--- a/src/js/helpers/pageType.js
+++ b/src/js/helpers/pageType.js
@@ -1,0 +1,6 @@
+export const isMuniCourt = (contextualNavData) => {
+  if (contextualNavData.offeredBy && contextualNavData.offeredBy[0].url === "/municipal-court/") {
+    return true
+  }
+  return false
+} 

--- a/src/js/helpers/pageType.js
+++ b/src/js/helpers/pageType.js
@@ -1,6 +1,11 @@
-export const isMuniCourt = (contextualNavData) => {
-  if (contextualNavData.offeredBy && contextualNavData.offeredBy[0].url === "/municipal-court/") {
-    return true
+export const isMuniCourt = contextualNavData => {
+  console.log(!!contextualNavData.offeredBy.length)
+  console.log(contextualNavData.offeredBy[0])
+  if (
+    !!contextualNavData.offeredBy.length &&
+    contextualNavData.offeredBy[0].url === '/municipal-court/'
+  ) {
+    return true;
   }
-  return false
-} 
+  return false;
+};

--- a/src/js/helpers/pageType.js
+++ b/src/js/helpers/pageType.js
@@ -1,6 +1,4 @@
 export const isMuniCourt = contextualNavData => {
-  console.log(!!contextualNavData.offeredBy.length)
-  console.log(contextualNavData.offeredBy[0])
   if (
     !!contextualNavData.offeredBy.length &&
     contextualNavData.offeredBy[0].url === '/municipal-court/'

--- a/src/js/i18n/locales/es.json
+++ b/src/js/i18n/locales/es.json
@@ -178,7 +178,7 @@
   "events.meetingCode": "Clave de acceso",
   "alert.getLatest": "Obtenga información actual sobre el coronavirus (COVID-19).",
   "alert.readMore": "Leer más",
-  "alert.location": "Las oficinas e instalaciones de la Ciudad de Austin quizás estén cerradas o tengan horario de emergencia temporal que no se ha actualizado en este sitio web",
+  "alert.location": "Las oficinas e instalaciones de la Ciudad de Austin quizás estén cerradas o tengan horario de emergencia temporal que no se ha actualizado en este sitio web.",
   "search.search": "Buscar",
   "search.results": "Resultados para {searchedTerm}",
   "search.noResultsHeader": "No hay resultados para su selección. Para mejorar los resultados de la búsqueda:",


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Municourt wants a TawkTo chat bot on their pages. We could add a flag on Joplin to turn on features like this, but in the interest of simplicity, I am checking the Contextual Navigation to see if the page is offered by Municipal Court. 

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
   <!--- Netlify Example: `https://janis-v3-<PR>.netlify.com/` --->  
https://janis-v3-5081-chat-bot.netlify.app/

Municipal Court handles the chat bot's settings and has it set so it is hidden when no one is there to receive the chats. Which makes it very hard to test on our end. 

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
