### PR TITLE
5054 Add virtual events to search

### DIFF
--- a/.circleci/scripts/branchConfig.js
+++ b/.circleci/scripts/branchConfig.js
@@ -33,20 +33,8 @@ const branchOverrides = {
     joplin_appname: 'joplin-pr-3690-incremental',
     REACT_STATIC_PREFETCH_RATE: '10',
   },
-  '4289-page-guide': {
-    joplin_appname: 'joplin-pr-v3',
-  },
-  '4611-gzip': {
-    joplin_appname: 'joplin',
-  },
-  'out-link': {
-    joplin_appname: 'joplin',
-  },
-  '5012-contact-slash': {
-    joplin_appname: 'joplin-pr-4940-virtual-event',
-  },
-  '4940-virtual-event': {
-    joplin_appname: 'joplin-pr-4940-virtual-event',
+  '5054-events-search': {
+    joplin_appname: 'joplin-pr-5054-events-search',
   },
 };
 

--- a/src/components/Pages/EventList/EventListEntry.js
+++ b/src/components/Pages/EventList/EventListEntry.js
@@ -55,6 +55,7 @@ const EventDateListDetails = ({
     eventUrl,
     canceled,
     feesRange,
+    locationNameSearch, // the location name that is returned in search results
   } = event;
   const noon = intl.formatMessage(i18n.noon);
 
@@ -113,7 +114,7 @@ const EventDateListDetails = ({
       <div className="coa-EventListPage__Title">
         <a href={eventUrl}>{title}</a>
       </div>
-      <div className="coa-EventListPage__Location">{locationName}</div>
+      <div className="coa-EventListPage__Location">{locationNameSearch || locationName}</div>
       <div className="coa-EventListPage__Cost">{`${cost} ${registration}`}</div>
     </div>
   );


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

This is the Janis component for the Joplin pull request adding virtual events to the search results. 

Location names are handled in search on the joplin, but they are parsed on the frontend for general events display. I changed the name on the search results to prevent confusion/breaking on the frontend.

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
[Joplin Related Pull Request Link](https://github.com/cityofaustin/joplin/pull/846)

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
   <!--- Netlify Example: `https://janis-v3-<PR>.netlify.com/` --->  
https://janis-v3-5054-events-search.netlify.app/en/search/?page=1&q=party

https://joplin-pr-5054-events-search.herokuapp.com/admin/pages/search/
I added events on joplin, search for "party" or "irl" on janis to see if they come up. 

admin@austintexas.io pw:x

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
