### PR TITLE
5075 - show pdf size in official documents

### DIFF
--- a/src/components/Pages/OfficialDocuments/OfficialDocumentEntry.js
+++ b/src/components/Pages/OfficialDocuments/OfficialDocumentEntry.js
@@ -25,7 +25,7 @@ const OfficialDocumentEntry = ({
 
   // If the link is a PDF with a pdfSize, then include it.
   const pdfComponent = (!!pdfSize) ?
-    <span className="coa-OfficialDocumentPage__pdf-size">(PDF {pdfSize})</span> :
+    <span className="coa-OfficialDocumentPage__pdf-size">(PDF {Math.round(pdfSize/100000)/10} MB)</span> :
     null
 
   // set the locale configuration for moment. Sets the locale for this component only


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Turns out we were getting the right information from the backend after all, we just weren't converting to MB. 

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
   <!--- Netlify Example: `https://janis-v3-<PR>.netlify.com/` --->  

compare: https://alpha.austin.gov/en/police-oversight/official-complaint-and-discipline-documents/

to: https://janis-v3-5075-pdf-size.netlify.app/en/police-oversight/official-complaint-and-discipline-documents/

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
