### PR TITLE
4703 - update secondary color

### DIFF
--- a/src/components/PageHeader/_PageHeader.scss
+++ b/src/components/PageHeader/_PageHeader.scss
@@ -112,7 +112,7 @@
 }
 
 .coa-PageHeader--event-list {
-  background-color: #f7f9fa;
+  background-color: $coa-color-secondary;
   padding-bottom: 40px;
   padding-top: 40px;
   padding-left: 10px;

--- a/src/components/Pages/Guide/_Guide.scss
+++ b/src/components/Pages/Guide/_Guide.scss
@@ -192,7 +192,7 @@ $max-guide-tablet-width: $coa-medium-screen;
 }
 
 .coa-GuideSection__header {
-  background: #ecf1f7;
+  background: #EDF5FF;
   text-align: center;
   font-weight: 500;
 

--- a/src/css/base/_variables.scss
+++ b/src/css/base/_variables.scss
@@ -85,7 +85,7 @@ $coa-color-half-primary: rgba(0, 80, 216, 0.5);
 $coa-color-almost-black: rgba(23, 23, 23, 1);
 $coa-color-decently-black: #212121;
 $coa-color-burnt-coffee-black: #2d2e2f;
-$coa-color-secondary: #f3f7fc;
+$coa-color-secondary: #EDF5FF;
 $coa-color-secondary-dark: #d9e8f6;
 $coa-color-grey: #f0f0f0;
 $coa-color-card-grey: #f7f7f7;


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Chase had an issue opened to tweak the secondary color so it's more harmonious with our other colors. 

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Joplin PR, link it here -->
<!--- [Joplin Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
   <!--- Netlify Example: `https://janis-v3-<PR>.netlify.com/` --->  
https://janis-v3-4703-header-color.netlify.app/en/housing-utilities/recycling-trash-and-compost/household-waste/bulk-item-pickup/

compared to:
https://alpha.austin.gov/en/housing-utilities/recycling-trash-and-compost/household-waste/bulk-item-pickup/

it's a subtle change. 

# Checklist:
- [x] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
